### PR TITLE
Standardize query language around start stop

### DIFF
--- a/src/praxxis/entrypoints/entry_library.py
+++ b/src/praxxis/entrypoints/entry_library.py
@@ -45,12 +45,12 @@ def remove_library(arg,
 
 def list_library(arg, 
                  library_db = _library_db,
-                start = _query_start,
+               query_start = _query_start,
                 stop = _query_end):
     """calls the function to list loaded libraries"""
     from src.praxxis.library import list_library
 
-    list_library.list_library(library_db, start, stop)
+    list_library.list_library(library_db,query_start, stop)
 
 
 def sync_library(arg, 

--- a/src/praxxis/entrypoints/entry_library.py
+++ b/src/praxxis/entrypoints/entry_library.py
@@ -46,11 +46,11 @@ def remove_library(arg,
 def list_library(arg, 
                  library_db = _library_db,
                query_start = _query_start,
-                stop = _query_end):
+                query_end = _query_end):
     """calls the function to list loaded libraries"""
     from src.praxxis.library import list_library
 
-    list_library.list_library(library_db,query_start, stop)
+    list_library.list_library(library_db,query_start, query_end)
 
 
 def sync_library(arg, 

--- a/src/praxxis/entrypoints/entry_notebook.py
+++ b/src/praxxis/entrypoints/entry_notebook.py
@@ -105,7 +105,7 @@ def next_notebook(arg,
                     current_scene_db = None,
                     library_db = _library_db,
                     rulesengine_db = _rulesengine_db,
-                    start = _query_start,
+                    query_start = _query_start,
                     end = _query_end):
     """calls the function to get the next notebook"""
     from src.praxxis.notebook import what_next
@@ -114,7 +114,7 @@ def next_notebook(arg,
     if current_scene_db == None:
         current_scene_db = roots.get_current_scene_db(scene_root, history_db)
 
-    what_next.what_next(arg, user_info_db, current_scene_db, library_db, rulesengine_db, start, end)
+    what_next.what_next(arg, user_info_db, current_scene_db, library_db, rulesengine_db, query_start, end)
 
 
 

--- a/src/praxxis/entrypoints/entry_notebook.py
+++ b/src/praxxis/entrypoints/entry_notebook.py
@@ -106,7 +106,7 @@ def next_notebook(arg,
                     library_db = _library_db,
                     rulesengine_db = _rulesengine_db,
                     query_start = _query_start,
-                    end = _query_end):
+                    query_end = _query_end):
     """calls the function to get the next notebook"""
     from src.praxxis.notebook import what_next
     from src.praxxis.util import roots
@@ -114,7 +114,7 @@ def next_notebook(arg,
     if current_scene_db == None:
         current_scene_db = roots.get_current_scene_db(scene_root, history_db)
 
-    what_next.what_next(arg, user_info_db, current_scene_db, library_db, rulesengine_db, query_start, end)
+    what_next.what_next(arg, user_info_db, current_scene_db, library_db, rulesengine_db, query_start, query_end)
 
 
 

--- a/src/praxxis/entrypoints/entry_parameter.py
+++ b/src/praxxis/entrypoints/entry_parameter.py
@@ -55,7 +55,7 @@ def view_library_param(arg,
                      scene_root = _scene_root,
                      history_db = _history_db,
                      library_db = _library_db,
-                     start = _query_start,
+                    query_start = _query_start,
                      end = _query_end,
                      current_scene_db = None):
     """ handles viewing library parameters from the CLI """
@@ -65,7 +65,7 @@ def view_library_param(arg,
     if current_scene_db == None:
         current_scene_db = roots.get_current_scene_db(scene_root, history_db)
 
-    list_param.list_library_param(arg, library_db, current_scene_db, start, end)
+    list_param.list_library_param(arg, library_db, current_scene_db,query_start, end)
 
 
 def view_notebook_param(arg, 
@@ -103,7 +103,7 @@ def pull_library_param(arg,
                       scene_root = _scene_root,
                       history_db = _history_db,
                       current_scene_db = None,
-                      start = _query_start,
+                     query_start = _query_start,
                       stop = _query_end):
     """ handles pulling parameters out of a library through the CLI. """
     from src.praxxis.parameter import pull_param
@@ -112,4 +112,4 @@ def pull_library_param(arg,
     if current_scene_db == None:
         current_scene_db = roots.get_current_scene_db(scene_root, history_db)
 
-    pull_param.pull_library_parameter(arg, library_db, current_scene_db, start, stop)
+    pull_param.pull_library_parameter(arg, library_db, current_scene_db,query_start, stop)

--- a/src/praxxis/entrypoints/entry_parameter.py
+++ b/src/praxxis/entrypoints/entry_parameter.py
@@ -55,8 +55,8 @@ def view_library_param(arg,
                      scene_root = _scene_root,
                      history_db = _history_db,
                      library_db = _library_db,
-                    query_start = _query_start,
-                     end = _query_end,
+                     query_start = _query_start,
+                     query_end = _query_end,
                      current_scene_db = None):
     """ handles viewing library parameters from the CLI """
     from src.praxxis.parameter import list_param
@@ -65,7 +65,7 @@ def view_library_param(arg,
     if current_scene_db == None:
         current_scene_db = roots.get_current_scene_db(scene_root, history_db)
 
-    list_param.list_library_param(arg, library_db, current_scene_db,query_start, end)
+    list_param.list_library_param(arg, library_db, current_scene_db,query_start, query_end)
 
 
 def view_notebook_param(arg, 

--- a/src/praxxis/entrypoints/entry_parameter.py
+++ b/src/praxxis/entrypoints/entry_parameter.py
@@ -104,7 +104,7 @@ def pull_library_param(arg,
                       history_db = _history_db,
                       current_scene_db = None,
                      query_start = _query_start,
-                      stop = _query_end):
+                      query_end = _query_end):
     """ handles pulling parameters out of a library through the CLI. """
     from src.praxxis.parameter import pull_param
     from src.praxxis.util import roots
@@ -112,4 +112,4 @@ def pull_library_param(arg,
     if current_scene_db == None:
         current_scene_db = roots.get_current_scene_db(scene_root, history_db)
 
-    pull_param.pull_library_parameter(arg, library_db, current_scene_db,query_start, stop)
+    pull_param.pull_library_parameter(arg, library_db, current_scene_db,query_start, query_end)

--- a/src/praxxis/entrypoints/entry_rulesengine.py
+++ b/src/praxxis/entrypoints/entry_rulesengine.py
@@ -34,10 +34,10 @@ def remove_ruleset(arg,
 def list_rulesets(arg,
                     rulesengine_db = _rulesengine_db,
                     query_start = _query_start,
-                    end = _query_end):
+                    query_end = _query_end):
     """calls the function to list all rulesets"""
     from src.praxxis.rulesengine import list_rulesets
-    list_rulesets.list_rulesets(arg, rulesengine_db, query_start, end)
+    list_rulesets.list_rulesets(arg, rulesengine_db, query_start, query_end)
     return
 
 
@@ -56,7 +56,7 @@ def edit_ruleset(arg,
                     scene_root = _scene_root,
                     history_db = _history_db,
                     query_start = _query_start,
-                    end = _query_end):
+                    query_end = _query_end):
     """calls the function to the edit the ruleset"""
     from src.praxxis.util import roots
     if current_scene_db == None:
@@ -78,14 +78,14 @@ def add_rule_to_ruleset(arg,
                     scene_root = _scene_root,
                     history_db = _history_db,
                     query_start = _query_start,
-                    end = _query_end):
+                    query_end = _query_end):
     """calls the function to add a rule to a ruleset"""
     from src.praxxis.util import roots
     if current_scene_db == None:
         current_scene_db = roots.get_current_scene_db(scene_root, history_db)
 
     from src.praxxis.rulesengine import add_rule_to_ruleset
-    add_rule_to_ruleset.add_rule_to_ruleset(arg, rulesengine_db, library_db, current_scene_db, query_start, end)
+    add_rule_to_ruleset.add_rule_to_ruleset(arg, rulesengine_db, library_db, current_scene_db, query_start, query_end)
 
 
 def delete_rule_from_ruleset(arg,

--- a/src/praxxis/entrypoints/entry_rulesengine.py
+++ b/src/praxxis/entrypoints/entry_rulesengine.py
@@ -33,11 +33,11 @@ def remove_ruleset(arg,
 
 def list_rulesets(arg,
                     rulesengine_db = _rulesengine_db,
-                    start = _query_start,
+                    query_start = _query_start,
                     end = _query_end):
     """calls the function to list all rulesets"""
     from src.praxxis.rulesengine import list_rulesets
-    list_rulesets.list_rulesets(arg, rulesengine_db, start, end)
+    list_rulesets.list_rulesets(arg, rulesengine_db, query_start, end)
     return
 
 
@@ -55,7 +55,7 @@ def edit_ruleset(arg,
                     current_scene_db = None,
                     scene_root = _scene_root,
                     history_db = _history_db,
-                    start = _query_start,
+                    query_start = _query_start,
                     end = _query_end):
     """calls the function to the edit the ruleset"""
     from src.praxxis.util import roots
@@ -77,7 +77,7 @@ def add_rule_to_ruleset(arg,
                     current_scene_db = None,
                     scene_root = _scene_root,
                     history_db = _history_db,
-                    start = _query_start,
+                    query_start = _query_start,
                     end = _query_end):
     """calls the function to add a rule to a ruleset"""
     from src.praxxis.util import roots
@@ -85,7 +85,7 @@ def add_rule_to_ruleset(arg,
         current_scene_db = roots.get_current_scene_db(scene_root, history_db)
 
     from src.praxxis.rulesengine import add_rule_to_ruleset
-    add_rule_to_ruleset.add_rule_to_ruleset(arg, rulesengine_db, library_db, current_scene_db, start, end)
+    add_rule_to_ruleset.add_rule_to_ruleset(arg, rulesengine_db, library_db, current_scene_db, query_start, end)
 
 
 def delete_rule_from_ruleset(arg,

--- a/src/praxxis/library/library.py
+++ b/src/praxxis/library/library.py
@@ -2,14 +2,14 @@
 library specific utilities
 """
 
-def get_library_by_ordinal(library_db, ordinal, query_start, end):
+def get_library_by_ordinal(library_db, ordinal, query_start, query_end):
     """gets library by ordinal using the sqlite history db"""
     from src.praxxis.sqlite import sqlite_library
     from src.praxxis.util import error
 
     if f"{ordinal}".isdigit():
         try:
-            library = sqlite_library.list_libraries(library_db, query_start, end)
+            library = sqlite_library.list_libraries(library_db, query_start, query_end)
         except error.LibraryNotFoundError as e:
             raise e
         else:

--- a/src/praxxis/library/library.py
+++ b/src/praxxis/library/library.py
@@ -2,14 +2,14 @@
 library specific utilities
 """
 
-def get_library_by_ordinal(library_db, ordinal, start, end):
+def get_library_by_ordinal(library_db, ordinal, query_start, end):
     """gets library by ordinal using the sqlite history db"""
     from src.praxxis.sqlite import sqlite_library
     from src.praxxis.util import error
 
     if f"{ordinal}".isdigit():
         try:
-            library = sqlite_library.list_libraries(library_db, start, end)
+            library = sqlite_library.list_libraries(library_db, query_start, end)
         except error.LibraryNotFoundError as e:
             raise e
         else:

--- a/src/praxxis/library/list_library.py
+++ b/src/praxxis/library/list_library.py
@@ -2,12 +2,12 @@
 This file prints a list of all notebook libraries installed on this machine.
 """
 
-def list_library(library_db, query_start, stop):
+def list_library(library_db, query_start, query_end):
     """grabs the list of libraries from the libraries db, and displays through 
     its display function"""
     from src.praxxis.sqlite import sqlite_library
     from src.praxxis.display import display_library
     
-    libraries = sqlite_library.list_libraries(library_db, query_start, stop)
+    libraries = sqlite_library.list_libraries(library_db, query_start, query_end)
     display_library.display_libraries(libraries)
     return libraries

--- a/src/praxxis/library/list_library.py
+++ b/src/praxxis/library/list_library.py
@@ -2,12 +2,12 @@
 This file prints a list of all notebook libraries installed on this machine.
 """
 
-def list_library(library_db, start, stop):
+def list_library(library_db, query_start, stop):
     """grabs the list of libraries from the libraries db, and displays through 
     its display function"""
     from src.praxxis.sqlite import sqlite_library
     from src.praxxis.display import display_library
     
-    libraries = sqlite_library.list_libraries(library_db, start, stop)
+    libraries = sqlite_library.list_libraries(library_db, query_start, stop)
     display_library.display_libraries(libraries)
     return libraries

--- a/src/praxxis/library/remove_library.py
+++ b/src/praxxis/library/remove_library.py
@@ -2,7 +2,7 @@
 removes a library by ordinal or name
 """
 
-def remove_library(args, library_db, query_start, end):
+def remove_library(args, library_db, query_start, query_end):
     """removes a library by ordinal or name"""
     from src.praxxis.sqlite import sqlite_library
     from src.praxxis.display import display_library
@@ -12,7 +12,7 @@ def remove_library(args, library_db, query_start, end):
 
     if name.isdigit():
         from src.praxxis.library import library
-        name = library.get_library_by_ordinal(library_db, name, query_start, end)
+        name = library.get_library_by_ordinal(library_db, name, query_start, query_end)
     
     sqlite_library.check_library_exists(library_db, name)
     sqlite_library.remove_library(library_db, name)

--- a/src/praxxis/library/remove_library.py
+++ b/src/praxxis/library/remove_library.py
@@ -2,7 +2,7 @@
 removes a library by ordinal or name
 """
 
-def remove_library(args, library_db, start, end):
+def remove_library(args, library_db, query_start, end):
     """removes a library by ordinal or name"""
     from src.praxxis.sqlite import sqlite_library
     from src.praxxis.display import display_library
@@ -12,7 +12,7 @@ def remove_library(args, library_db, start, end):
 
     if name.isdigit():
         from src.praxxis.library import library
-        name = library.get_library_by_ordinal(library_db, name, start, end)
+        name = library.get_library_by_ordinal(library_db, name, query_start, end)
     
     sqlite_library.check_library_exists(library_db, name)
     sqlite_library.remove_library(library_db, name)

--- a/src/praxxis/model/import_model.py
+++ b/src/praxxis/model/import_model.py
@@ -1,4 +1,4 @@
-def import_model(args, prediction_db):
+def import_model(args, model_db):
     from src.praxxis.sqlite import sqlite_model
     from src.praxxis.display import display_model
     import os
@@ -8,5 +8,5 @@ def import_model(args, prediction_db):
 
     model_name = os.path.basename(model_path)
 
-    sqlite_model.add_model(prediction_db, model_name, model_path, converter_path)
+    sqlite_model.add_model(model_db, model_name, model_path, converter_path)
     display_model.display_imported_model(model_name)

--- a/src/praxxis/model/score.py
+++ b/src/praxxis/model/score.py
@@ -50,7 +50,7 @@ def predict(sequence, model_path, converter_path):
     # convert results into meaningful thing
     print(pd.Series(data[0], converter).sort_values(ascending=False))
 
-def get_files(prediction_db):
+def get_files(model_db):
     pass
     
  

--- a/src/praxxis/notebook/list_notebook.py
+++ b/src/praxxis/notebook/list_notebook.py
@@ -2,12 +2,12 @@
 This file lists all of the notebooks loaded into the library db file
 """
         
-def list_notebook(library_db, current_scene_db, query_start, stop):
+def list_notebook(library_db, current_scene_db, query_start, query_end):
     """ gets the notebooks from the sqlite db and displays them through its display function"""
     from src.praxxis.sqlite import sqlite_notebook
     from src.praxxis.display import display_notebook
 
-    notebooks = sqlite_notebook.list_notebooks(library_db, query_start, stop)
+    notebooks = sqlite_notebook.list_notebooks(library_db, query_start, query_end)
     sqlite_notebook.write_list(current_scene_db, notebooks)
     display_notebook.display_list_notebook(notebooks)
     return notebooks

--- a/src/praxxis/notebook/list_notebook.py
+++ b/src/praxxis/notebook/list_notebook.py
@@ -2,12 +2,12 @@
 This file lists all of the notebooks loaded into the library db file
 """
         
-def list_notebook(library_db, current_scene_db, start, stop):
+def list_notebook(library_db, current_scene_db, query_start, stop):
     """ gets the notebooks from the sqlite db and displays them through its display function"""
     from src.praxxis.sqlite import sqlite_notebook
     from src.praxxis.display import display_notebook
 
-    notebooks = sqlite_notebook.list_notebooks(library_db, start, stop)
+    notebooks = sqlite_notebook.list_notebooks(library_db, query_start, stop)
     sqlite_notebook.write_list(current_scene_db, notebooks)
     display_notebook.display_list_notebook(notebooks)
     return notebooks

--- a/src/praxxis/notebook/run_notebook.py
+++ b/src/praxxis/notebook/run_notebook.py
@@ -5,7 +5,7 @@ opened as an html output in the web browser, depending on user input.
 
 from src.praxxis.sqlite import sqlite_telemetry 
 
-def run_notebook(args, user_info_db, output_root, current_scene_db, library_root, library_db, start, stop):
+def run_notebook(args, user_info_db, output_root, current_scene_db, library_root, library_db, query_start, stop):
     """runs a single notebook specified in args and sends telemetry"""
     from src.praxxis.display import display_notebook
     from src.praxxis.notebook import notebook

--- a/src/praxxis/notebook/run_notebook.py
+++ b/src/praxxis/notebook/run_notebook.py
@@ -5,7 +5,7 @@ opened as an html output in the web browser, depending on user input.
 
 from src.praxxis.sqlite import sqlite_telemetry 
 
-def run_notebook(args, user_info_db, output_root, current_scene_db, library_root, library_db, query_start, stop):
+def run_notebook(args, user_info_db, output_root, current_scene_db, library_root, library_db, query_start, query_end):
     """runs a single notebook specified in args and sends telemetry"""
     from src.praxxis.display import display_notebook
     from src.praxxis.notebook import notebook

--- a/src/praxxis/notebook/search_notebook.py
+++ b/src/praxxis/notebook/search_notebook.py
@@ -3,13 +3,13 @@ Searches notebooks for search term using a sql query, and calls the display func
 """
 import os
 
-def search_notebook(args, library_db, current_scene_db, start, end):
+def search_notebook(args, library_db, current_scene_db, query_start, end):
     """ searches and displays loaded notebooks"""
     from src.praxxis.sqlite import sqlite_notebook
     from src.praxxis.display import display_notebook
 
     search_term = args.term
-    notebooks = sqlite_notebook.search_notebooks(library_db, search_term, start, end)
+    notebooks = sqlite_notebook.search_notebooks(library_db, search_term, query_start, end)
     display_notebook.display_search(search_term, notebooks)
     sqlite_notebook.write_list(current_scene_db, notebooks)
     return notebooks

--- a/src/praxxis/notebook/search_notebook.py
+++ b/src/praxxis/notebook/search_notebook.py
@@ -3,13 +3,13 @@ Searches notebooks for search term using a sql query, and calls the display func
 """
 import os
 
-def search_notebook(args, library_db, current_scene_db, query_start, end):
+def search_notebook(args, library_db, current_scene_db, query_start, query_end):
     """ searches and displays loaded notebooks"""
     from src.praxxis.sqlite import sqlite_notebook
     from src.praxxis.display import display_notebook
 
     search_term = args.term
-    notebooks = sqlite_notebook.search_notebooks(library_db, search_term, query_start, end)
+    notebooks = sqlite_notebook.search_notebooks(library_db, search_term, query_start, query_end)
     display_notebook.display_search(search_term, notebooks)
     sqlite_notebook.write_list(current_scene_db, notebooks)
     return notebooks

--- a/src/praxxis/notebook/what_next.py
+++ b/src/praxxis/notebook/what_next.py
@@ -11,7 +11,7 @@ from src.praxxis.sqlite import sqlite_scene
 from src.praxxis.rulesengine import rules_checker
 
 
-def what_next(args, user_info_db, current_scene_db, library_db, prediction_db, query_start, end):
+def what_next(args, user_info_db, current_scene_db, library_db, rulesengine_db, query_start, end):
     """calls prediction endpoints to get next notebooks"""
     from src.praxxis.display import display_rulesengine
     history = sqlite_scene.get_recent_history(current_scene_db, 5)
@@ -19,7 +19,7 @@ def what_next(args, user_info_db, current_scene_db, library_db, prediction_db, q
         from src.praxxis.util.error import EmptyHistoryError
         raise EmptyHistoryError()
 
-    rules_based = rules_checker.rules_check(prediction_db, history[-1][0], history[-1][1], query_start, end)
+    rules_based = rules_checker.rules_check(rulesengine_db, history[-1][0], history[-1][1], query_start, end)
     if rules_based != []:
         display_rulesengine.display_predictions(rules_based)
         write_to_list(rules_based, current_scene_db, library_db)

--- a/src/praxxis/notebook/what_next.py
+++ b/src/praxxis/notebook/what_next.py
@@ -11,15 +11,15 @@ from src.praxxis.sqlite import sqlite_scene
 from src.praxxis.rulesengine import rules_checker
 
 
-def what_next(args, user_info_db, current_scene_db, library_db, rulesengine_db, query_start, end):
-    """calls prediction endpoints to get next notebooks"""
+def what_next(args, user_info_db, current_scene_db, library_db, rulesengine_db, query_start, query_end):
+    """calls prediction query_endpoints to get next notebooks"""
     from src.praxxis.display import display_rulesengine
     history = sqlite_scene.get_recent_history(current_scene_db, 5)
     if history == []:
         from src.praxxis.util.error import EmptyHistoryError
         raise EmptyHistoryError()
 
-    rules_based = rules_checker.rules_check(rulesengine_db, history[-1][0], history[-1][1], query_start, end)
+    rules_based = rules_checker.rules_check(rulesengine_db, history[-1][0], history[-1][1], query_start, query_end)
     if rules_based != []:
         display_rulesengine.display_predictions(rules_based)
         write_to_list(rules_based, current_scene_db, library_db)

--- a/src/praxxis/notebook/what_next.py
+++ b/src/praxxis/notebook/what_next.py
@@ -11,7 +11,7 @@ from src.praxxis.sqlite import sqlite_scene
 from src.praxxis.rulesengine import rules_checker
 
 
-def what_next(args, user_info_db, current_scene_db, library_db, prediction_db, start, end):
+def what_next(args, user_info_db, current_scene_db, library_db, prediction_db, query_start, end):
     """calls prediction endpoints to get next notebooks"""
     from src.praxxis.display import display_rulesengine
     history = sqlite_scene.get_recent_history(current_scene_db, 5)
@@ -19,7 +19,7 @@ def what_next(args, user_info_db, current_scene_db, library_db, prediction_db, s
         from src.praxxis.util.error import EmptyHistoryError
         raise EmptyHistoryError()
 
-    rules_based = rules_checker.rules_check(prediction_db, history[-1][0], history[-1][1], start, end)
+    rules_based = rules_checker.rules_check(prediction_db, history[-1][0], history[-1][1], query_start, end)
     if rules_based != []:
         display_rulesengine.display_predictions(rules_based)
         write_to_list(rules_based, current_scene_db, library_db)

--- a/src/praxxis/parameter/list_param.py
+++ b/src/praxxis/parameter/list_param.py
@@ -2,14 +2,14 @@
 This file lists all of the parameters
 """
 
-def list_param(current_scene_db, start, end):
+def list_param(current_scene_db, query_start, end):
     """lists the parameters in scene"""
     import os
     from src.praxxis.sqlite import sqlite_scene
     from src.praxxis.sqlite import sqlite_parameter
     from src.praxxis.display import display_param
     
-    param_list = sqlite_parameter.list_param(current_scene_db, start, end)
+    param_list = sqlite_parameter.list_param(current_scene_db, query_start, end)
 
     display_param.display_list_param(param_list)
     return param_list
@@ -37,7 +37,7 @@ def list_notebook_param(args, library_db, current_scene_db):
     return parameters
 
 
-def list_library_param(args, library_db, current_scene_db, start, end):
+def list_library_param(args, library_db, current_scene_db, query_start, end):
     """Lists all parameters in the """
     from src.praxxis.sqlite import sqlite_parameter
     from src.praxxis.display import display_param
@@ -50,7 +50,7 @@ def list_library_param(args, library_db, current_scene_db, start, end):
         name = args
 
     if name.isdigit():
-        name = library.get_library_by_ordinal(library_db, name, start, end)
+        name = library.get_library_by_ordinal(library_db, name, query_start, end)
             
     try:
         parameters = sqlite_parameter.get_library_parameters(library_db, name)

--- a/src/praxxis/parameter/list_param.py
+++ b/src/praxxis/parameter/list_param.py
@@ -2,14 +2,14 @@
 This file lists all of the parameters
 """
 
-def list_param(current_scene_db, query_start, end):
+def list_param(current_scene_db, query_start, query_end):
     """lists the parameters in scene"""
     import os
     from src.praxxis.sqlite import sqlite_scene
     from src.praxxis.sqlite import sqlite_parameter
     from src.praxxis.display import display_param
     
-    param_list = sqlite_parameter.list_param(current_scene_db, query_start, end)
+    param_list = sqlite_parameter.list_param(current_scene_db, query_start, query_end)
 
     display_param.display_list_param(param_list)
     return param_list
@@ -37,7 +37,7 @@ def list_notebook_param(args, library_db, current_scene_db):
     return parameters
 
 
-def list_library_param(args, library_db, current_scene_db, query_start, end):
+def list_library_param(args, library_db, current_scene_db, query_start, query_end):
     """Lists all parameters in the """
     from src.praxxis.sqlite import sqlite_parameter
     from src.praxxis.display import display_param
@@ -50,7 +50,7 @@ def list_library_param(args, library_db, current_scene_db, query_start, end):
         name = args
 
     if name.isdigit():
-        name = library.get_library_by_ordinal(library_db, name, query_start, end)
+        name = library.get_library_by_ordinal(library_db, name, query_start, query_end)
             
     try:
         parameters = sqlite_parameter.get_library_parameters(library_db, name)

--- a/src/praxxis/parameter/pull_param.py
+++ b/src/praxxis/parameter/pull_param.py
@@ -6,9 +6,9 @@ def pull_notebook_parameter(args, library_db, current_scene_db):
     sqlite_parameter.set_many_params(current_scene_db, params)
 
 
-def pull_library_parameter(args, library_db, current_scene_db, start, stop):
+def pull_library_parameter(args, library_db, current_scene_db, query_start, stop):
     from src.praxxis.sqlite import sqlite_parameter
     from src.praxxis.parameter import list_param
 
-    params = list_param.list_library_param(args, library_db, current_scene_db, start, stop)
+    params = list_param.list_library_param(args, library_db, current_scene_db, query_start, stop)
     sqlite_parameter.set_many_params(current_scene_db, params)

--- a/src/praxxis/parameter/pull_param.py
+++ b/src/praxxis/parameter/pull_param.py
@@ -6,9 +6,9 @@ def pull_notebook_parameter(args, library_db, current_scene_db):
     sqlite_parameter.set_many_params(current_scene_db, params)
 
 
-def pull_library_parameter(args, library_db, current_scene_db, query_start, stop):
+def pull_library_parameter(args, library_db, current_scene_db, query_start, query_end):
     from src.praxxis.sqlite import sqlite_parameter
     from src.praxxis.parameter import list_param
 
-    params = list_param.list_library_param(args, library_db, current_scene_db, query_start, stop)
+    params = list_param.list_library_param(args, library_db, current_scene_db, query_start, query_end)
     sqlite_parameter.set_many_params(current_scene_db, params)

--- a/src/praxxis/rulesengine/activate_ruleset.py
+++ b/src/praxxis/rulesengine/activate_ruleset.py
@@ -3,7 +3,7 @@ Marks a ruleset as activate
 (i.e., its rules will be evaluated when making predictions)
 """
 
-def activate_ruleset(args, prediction_db):
+def activate_ruleset(args, rulesengine_db):
     from src.praxxis.sqlite import sqlite_rulesengine
     from src.praxxis.display import display_rulesengine
     from src.praxxis.rulesengine import rules
@@ -14,10 +14,10 @@ def activate_ruleset(args, prediction_db):
     else:
         name = args
 
-    name = rules.get_ruleset_by_ordinal(name, prediction_db)
+    name = rules.get_ruleset_by_ordinal(name, rulesengine_db)
 
     try:
-        sqlite_rulesengine.activate_ruleset(prediction_db, name)
+        sqlite_rulesengine.activate_ruleset(rulesengine_db, name)
         display_rulesengine.display_activate_ruleset(name)
         return name
     except error.RulesetNotFoundError as e:

--- a/src/praxxis/rulesengine/add_rule_to_ruleset.py
+++ b/src/praxxis/rulesengine/add_rule_to_ruleset.py
@@ -2,7 +2,7 @@
 Adds a rule to the ruleset by user inputs in a console dialog
 """
 
-def add_rule_to_ruleset(args, rulesengine_db, library_db, current_scene_db, start, stop):
+def add_rule_to_ruleset(args, rulesengine_db, library_db, current_scene_db, query_start, stop):
     """prompts user through adding a rule, given a ruleset"""
     from src.praxxis.sqlite import sqlite_rulesengine
     from src.praxxis.display import display_rulesengine
@@ -24,7 +24,7 @@ def add_rule_to_ruleset(args, rulesengine_db, library_db, current_scene_db, star
     rulename = display_edit_ruleset.display_get_rule_name()
     
     # get filenames 
-    list_notebook(library_db, current_scene_db, start, stop)
+    list_notebook(library_db, current_scene_db, query_start, stop)
     filenames_raw = display_edit_ruleset.display_filename_input()
     filenames_with_ords = [string.strip().strip('"').strip('\'') for string in filenames_raw.split(",")]
     filenames = get_filenames_from_ordinals(filenames_with_ords, current_scene_db)
@@ -36,7 +36,7 @@ def add_rule_to_ruleset(args, rulesengine_db, library_db, current_scene_db, star
     display_edit_ruleset.display_outputs(output)
 
     # get predicted notebooks
-    list_notebook(library_db, current_scene_db, start, stop)
+    list_notebook(library_db, current_scene_db, query_start, stop)
     predicted_raw = display_edit_ruleset.display_predicted_notebooks_input()
     predicted_with_ords = [prediction.strip() for prediction in predicted_raw.split(",")]
     predicted = get_fileinfo_from_ordinals(predicted_with_ords, current_scene_db, rulename)

--- a/src/praxxis/rulesengine/add_rule_to_ruleset.py
+++ b/src/praxxis/rulesengine/add_rule_to_ruleset.py
@@ -2,7 +2,7 @@
 Adds a rule to the ruleset by user inputs in a console dialog
 """
 
-def add_rule_to_ruleset(args, rulesengine_db, library_db, current_scene_db, query_start, stop):
+def add_rule_to_ruleset(args, rulesengine_db, library_db, current_scene_db, query_start, query_end):
     """prompts user through adding a rule, given a ruleset"""
     from src.praxxis.sqlite import sqlite_rulesengine
     from src.praxxis.display import display_rulesengine
@@ -24,7 +24,7 @@ def add_rule_to_ruleset(args, rulesengine_db, library_db, current_scene_db, quer
     rulename = display_edit_ruleset.display_get_rule_name()
     
     # get filenames 
-    list_notebook(library_db, current_scene_db, query_start, stop)
+    list_notebook(library_db, current_scene_db, query_start, query_end)
     filenames_raw = display_edit_ruleset.display_filename_input()
     filenames_with_ords = [string.strip().strip('"').strip('\'') for string in filenames_raw.split(",")]
     filenames = get_filenames_from_ordinals(filenames_with_ords, current_scene_db)
@@ -36,7 +36,7 @@ def add_rule_to_ruleset(args, rulesengine_db, library_db, current_scene_db, quer
     display_edit_ruleset.display_outputs(output)
 
     # get predicted notebooks
-    list_notebook(library_db, current_scene_db, query_start, stop)
+    list_notebook(library_db, current_scene_db, query_start, query_end)
     predicted_raw = display_edit_ruleset.display_predicted_notebooks_input()
     predicted_with_ords = [prediction.strip() for prediction in predicted_raw.split(",")]
     predicted = get_fileinfo_from_ordinals(predicted_with_ords, current_scene_db, rulename)

--- a/src/praxxis/rulesengine/deactivate_ruleset.py
+++ b/src/praxxis/rulesengine/deactivate_ruleset.py
@@ -3,7 +3,7 @@ Deactivates a ruleset.
 (i.e., the ruleset remains on disk but will not be used in making predictions)
 """
 
-def deactivate_ruleset(args, prediction_db):
+def deactivate_ruleset(args, rulesengine_db):
     from src.praxxis.sqlite import sqlite_rulesengine
     from src.praxxis.display import display_rulesengine
     from src.praxxis.rulesengine import rules
@@ -13,8 +13,8 @@ def deactivate_ruleset(args, prediction_db):
     else:
         name = args
 
-    name = rules.get_ruleset_by_ordinal(name, prediction_db)
+    name = rules.get_ruleset_by_ordinal(name, rulesengine_db)
 
-    sqlite_rulesengine.deactivate_ruleset(prediction_db, name)
+    sqlite_rulesengine.deactivate_ruleset(rulesengine_db, name)
     display_rulesengine.display_deactivate_ruleset(name)
     return name

--- a/src/praxxis/rulesengine/delete_rule_from_ruleset.py
+++ b/src/praxxis/rulesengine/delete_rule_from_ruleset.py
@@ -2,7 +2,7 @@
 Deletes a rule from a ruleset, based on user input in the console.
 """
 
-def delete_rule_from_ruleset(args, prediction_db):
+def delete_rule_from_ruleset(args, rulesengine_db):
     from src.praxxis.sqlite import sqlite_rulesengine
     from src.praxxis.display import display_rulesengine
     from src.praxxis.display import display_edit_ruleset
@@ -14,8 +14,8 @@ def delete_rule_from_ruleset(args, prediction_db):
         name = args
 
     # get ruleset info
-    name = rules.get_ruleset_by_ordinal(name, prediction_db)
-    ruleset_db = sqlite_rulesengine.get_ruleset_path(prediction_db, name)
+    name = rules.get_ruleset_by_ordinal(name, rulesengine_db)
+    ruleset_db = sqlite_rulesengine.get_ruleset_path(rulesengine_db, name)
 
     # give the user a list of rules and ask which one to delete
     rules_list = sqlite_rulesengine.list_rules_in_ruleset(ruleset_db)

--- a/src/praxxis/rulesengine/list_rulesets.py
+++ b/src/praxxis/rulesengine/list_rulesets.py
@@ -2,12 +2,12 @@
 This file lists all rulesets by name
 """
 
-def list_rulesets(args, rulesengine_db, query_start, end):
+def list_rulesets(args, rulesengine_db, query_start, query_end):
     """lists all rulesets and whether each is currently activated"""
     from src.praxxis.sqlite import sqlite_rulesengine
     from src.praxxis.display import display_rulesengine
 
-    result = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start, end)
+    result = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start, query_end)
     display_rulesengine.display_ruleset_list(result)
     
     return result

--- a/src/praxxis/rulesengine/list_rulesets.py
+++ b/src/praxxis/rulesengine/list_rulesets.py
@@ -2,12 +2,12 @@
 This file lists all rulesets by name
 """
 
-def list_rulesets(args, prediction_db, query_start, end):
+def list_rulesets(args, rulesengine_db, query_start, end):
     """lists all rulesets and whether each is currently activated"""
     from src.praxxis.sqlite import sqlite_rulesengine
     from src.praxxis.display import display_rulesengine
 
-    result = sqlite_rulesengine.get_all_rulesets(prediction_db, query_start, end)
+    result = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start, end)
     display_rulesengine.display_ruleset_list(result)
     
     return result

--- a/src/praxxis/rulesengine/list_rulesets.py
+++ b/src/praxxis/rulesengine/list_rulesets.py
@@ -2,12 +2,12 @@
 This file lists all rulesets by name
 """
 
-def list_rulesets(args, prediction_db, start, end):
+def list_rulesets(args, prediction_db, query_start, end):
     """lists all rulesets and whether each is currently activated"""
     from src.praxxis.sqlite import sqlite_rulesengine
     from src.praxxis.display import display_rulesengine
 
-    result = sqlite_rulesengine.get_all_rulesets(prediction_db, start, end)
+    result = sqlite_rulesengine.get_all_rulesets(prediction_db, query_start, end)
     display_rulesengine.display_ruleset_list(result)
     
     return result

--- a/src/praxxis/rulesengine/rules.py
+++ b/src/praxxis/rulesengine/rules.py
@@ -1,13 +1,13 @@
 """utilities for rules engine operation"""
 
-def get_ruleset_by_ordinal(name, prediction_db):
+def get_ruleset_by_ordinal(name, rulesengine_db):
     """gets ruleset by ordinal using the sqlite prediction db"""
     from src.praxxis.sqlite import sqlite_rulesengine
     from src.praxxis.util import error
 
     if f"{name}".isdigit():
         try:
-            name = sqlite_rulesengine.get_ruleset_by_ord(prediction_db, int(name))
+            name = sqlite_rulesengine.get_ruleset_by_ord(rulesengine_db, int(name))
         except error.RulesetNotFoundError as e:
             raise e
     return(name)

--- a/src/praxxis/rulesengine/rules_checker.py
+++ b/src/praxxis/rulesengine/rules_checker.py
@@ -6,11 +6,11 @@ Rules are defined as:
 if either left-hand list is empty, this is interpreted as "all"
 """
 
-def rules_check(rulesengine_db, filename, output_path, query_start, end):
+def rules_check(rulesengine_db, filename, output_path, query_start, query_end):
     """check if any rules match"""
     from src.praxxis.sqlite import sqlite_rulesengine
 
-    rulesets = sqlite_rulesengine.get_active_rulesets(rulesengine_db, query_start, end)
+    rulesets = sqlite_rulesengine.get_active_rulesets(rulesengine_db, query_start, query_end)
 
     rulesmatch = []
     hit = set()

--- a/src/praxxis/rulesengine/rules_checker.py
+++ b/src/praxxis/rulesengine/rules_checker.py
@@ -6,11 +6,11 @@ Rules are defined as:
 if either left-hand list is empty, this is interpreted as "all"
 """
 
-def rules_check(prediction_db, filename, output_path, query_start, end):
+def rules_check(rulesengine_db, filename, output_path, query_start, end):
     """check if any rules match"""
     from src.praxxis.sqlite import sqlite_rulesengine
 
-    rulesets = sqlite_rulesengine.get_active_rulesets(prediction_db, query_start, end)
+    rulesets = sqlite_rulesengine.get_active_rulesets(rulesengine_db, query_start, end)
 
     rulesmatch = []
     hit = set()

--- a/src/praxxis/rulesengine/rules_checker.py
+++ b/src/praxxis/rulesengine/rules_checker.py
@@ -6,11 +6,11 @@ Rules are defined as:
 if either left-hand list is empty, this is interpreted as "all"
 """
 
-def rules_check(prediction_db, filename, output_path, start, end):
+def rules_check(prediction_db, filename, output_path, query_start, end):
     """check if any rules match"""
     from src.praxxis.sqlite import sqlite_rulesengine
 
-    rulesets = sqlite_rulesengine.get_active_rulesets(prediction_db, start, end)
+    rulesets = sqlite_rulesengine.get_active_rulesets(prediction_db, query_start, end)
 
     rulesmatch = []
     hit = set()

--- a/src/praxxis/rulesengine/view_rules.py
+++ b/src/praxxis/rulesengine/view_rules.py
@@ -2,7 +2,7 @@
 View a list of all rules in a ruleset
 TODO: -v option to see rule definitions too
 """ 
-def view_rules(args, prediction_db):
+def view_rules(args, rulesengine_db):
     """view rules in a given ruleset"""
     from src.praxxis.sqlite import sqlite_rulesengine
     from src.praxxis.display import display_rulesengine
@@ -14,9 +14,9 @@ def view_rules(args, prediction_db):
         name = args
 
        
-    name = rules.get_ruleset_by_ordinal(name, prediction_db)
+    name = rules.get_ruleset_by_ordinal(name, rulesengine_db)
 
-    ruleset_db = sqlite_rulesengine.get_ruleset_path(prediction_db, name)
+    ruleset_db = sqlite_rulesengine.get_ruleset_path(rulesengine_db, name)
 
     rules_list = sqlite_rulesengine.list_rules_in_ruleset(ruleset_db)
     display_rulesengine.display_rule_list(name, rules_list)

--- a/src/praxxis/sqlite/sqlite_library.py
+++ b/src/praxxis/sqlite/sqlite_library.py
@@ -84,13 +84,13 @@ def sync_library(library_db, path, readme, library, remote=None):
 
     
 
-def list_libraries(library_db, query_start, end):
+def list_libraries(library_db, query_start, query_end):
     """returns a list of loaded libraries"""
     from src.praxxis.sqlite import connection
 
     conn = connection.create_connection(library_db)
     cur = conn.cursor()
-    list_libraries = f'SELECT Library FROM "LibraryMetadata" ORDER BY Library LIMIT {query_start}, {end}'
+    list_libraries = f'SELECT Library FROM "LibraryMetadata" ORDER BY Library LIMIT {query_start}, {query_end}'
     cur.execute(list_libraries)
     conn.commit()
     rows = cur.fetchall()

--- a/src/praxxis/sqlite/sqlite_library.py
+++ b/src/praxxis/sqlite/sqlite_library.py
@@ -84,13 +84,13 @@ def sync_library(library_db, path, readme, library, remote=None):
 
     
 
-def list_libraries(library_db, start, end):
+def list_libraries(library_db, query_start, end):
     """returns a list of loaded libraries"""
     from src.praxxis.sqlite import connection
 
     conn = connection.create_connection(library_db)
     cur = conn.cursor()
-    list_libraries = f'SELECT Library FROM "LibraryMetadata" ORDER BY Library LIMIT {start}, {end}'
+    list_libraries = f'SELECT Library FROM "LibraryMetadata" ORDER BY Library LIMIT {query_start}, {end}'
     cur.execute(list_libraries)
     conn.commit()
     rows = cur.fetchall()

--- a/src/praxxis/sqlite/sqlite_notebook.py
+++ b/src/praxxis/sqlite/sqlite_notebook.py
@@ -2,13 +2,13 @@
 This file contains the sqlite functions for notebooks
 """
 
-def list_notebooks(library_db, start, end):
+def list_notebooks(library_db, query_start, end):
     """lists all loaded notebooks"""
     from src.praxxis.sqlite import connection
 
     conn = connection.create_connection(library_db)
     cur = conn.cursor()
-    list_libraries = f'SELECT Notebook, Path, Library, RawUrl FROM "Notebooks" LIMIT {start}, {end}'
+    list_libraries = f'SELECT Notebook, Path, Library, RawUrl FROM "Notebooks" LIMIT {query_start}, {end}'
     cur.execute(list_libraries)
     rows = cur.fetchall()
     conn.close()
@@ -123,13 +123,13 @@ def check_notebook_exists(library_db, notebook):
         return 0
 
 
-def search_notebooks(library_db, search_term, start, end):
+def search_notebooks(library_db, search_term, query_start, end):
     """searches notebooks for search term"""
     from src.praxxis.sqlite import connection
 
     conn = connection.create_connection(library_db)
     cur = conn.cursor()
-    list_param = f'SELECT Notebook, Path, Library, RawUrl FROM "Notebooks" WHERE Notebook LIKE "%{search_term}%" ORDER BY Notebook LIMIT {start}, {end}'
+    list_param = f'SELECT Notebook, Path, Library, RawUrl FROM "Notebooks" WHERE Notebook LIKE "%{search_term}%" ORDER BY Notebook LIMIT {query_start}, {end}'
     cur.execute(list_param)
     conn.commit()
     rows = cur.fetchall()

--- a/src/praxxis/sqlite/sqlite_notebook.py
+++ b/src/praxxis/sqlite/sqlite_notebook.py
@@ -2,13 +2,13 @@
 This file contains the sqlite functions for notebooks
 """
 
-def list_notebooks(library_db, query_start, end):
+def list_notebooks(library_db, query_start, query_end):
     """lists all loaded notebooks"""
     from src.praxxis.sqlite import connection
 
     conn = connection.create_connection(library_db)
     cur = conn.cursor()
-    list_libraries = f'SELECT Notebook, Path, Library, RawUrl FROM "Notebooks" LIMIT {query_start}, {end}'
+    list_libraries = f'SELECT Notebook, Path, Library, RawUrl FROM "Notebooks" LIMIT {query_start}, {query_end}'
     cur.execute(list_libraries)
     rows = cur.fetchall()
     conn.close()
@@ -123,13 +123,13 @@ def check_notebook_exists(library_db, notebook):
         return 0
 
 
-def search_notebooks(library_db, search_term, query_start, end):
+def search_notebooks(library_db, search_term, query_start, query_end):
     """searches notebooks for search term"""
     from src.praxxis.sqlite import connection
 
     conn = connection.create_connection(library_db)
     cur = conn.cursor()
-    list_param = f'SELECT Notebook, Path, Library, RawUrl FROM "Notebooks" WHERE Notebook LIKE "%{search_term}%" ORDER BY Notebook LIMIT {query_start}, {end}'
+    list_param = f'SELECT Notebook, Path, Library, RawUrl FROM "Notebooks" WHERE Notebook LIKE "%{search_term}%" ORDER BY Notebook LIMIT {query_start}, {query_end}'
     cur.execute(list_param)
     conn.commit()
     rows = cur.fetchall()

--- a/src/praxxis/sqlite/sqlite_parameter.py
+++ b/src/praxxis/sqlite/sqlite_parameter.py
@@ -47,13 +47,13 @@ def get_library_parameters(library_db, library):
     return parameters
 
 
-def list_param(current_scene_db, query_start, end):
+def list_param(current_scene_db, query_start, query_end):
     """returns a list of set parameters in the scene"""
     from src.praxxis.sqlite import connection
 
     conn = connection.create_connection(current_scene_db)
     cur = conn.cursor()
-    list_param = f'SELECT * FROM "Parameters" ORDER BY Parameter DESC LIMIT {query_start}, {end}'
+    list_param = f'SELECT * FROM "Parameters" ORDER BY Parameter DESC LIMIT {query_start}, {query_end}'
     cur.execute(list_param)
     conn.commit()
     rows = cur.fetchall()

--- a/src/praxxis/sqlite/sqlite_parameter.py
+++ b/src/praxxis/sqlite/sqlite_parameter.py
@@ -47,13 +47,13 @@ def get_library_parameters(library_db, library):
     return parameters
 
 
-def list_param(current_scene_db, start, end):
+def list_param(current_scene_db, query_start, end):
     """returns a list of set parameters in the scene"""
     from src.praxxis.sqlite import connection
 
     conn = connection.create_connection(current_scene_db)
     cur = conn.cursor()
-    list_param = f'SELECT * FROM "Parameters" ORDER BY Parameter DESC LIMIT {start}, {end}'
+    list_param = f'SELECT * FROM "Parameters" ORDER BY Parameter DESC LIMIT {query_start}, {end}'
     cur.execute(list_param)
     conn.commit()
     rows = cur.fetchall()

--- a/src/praxxis/sqlite/sqlite_rulesengine.py
+++ b/src/praxxis/sqlite/sqlite_rulesengine.py
@@ -79,7 +79,7 @@ def get_ruleset_by_ord(rulesengine_db, ordinal):
         raise error.RulesetNotFoundError(ordinal)
     return rows[0][0]
 
-def get_all_rulesets(rulesengine_db, start, end):
+def get_all_rulesets(rulesengine_db, query_start, end):
     """gets all rulesets"""
     from src.praxxis.sqlite import connection
     
@@ -93,7 +93,7 @@ def get_all_rulesets(rulesengine_db, start, end):
 
     return rows
 
-def get_active_rulesets(rulesengine_db, start, end):
+def get_active_rulesets(rulesengine_db, query_start, end):
     """gets all active rulesets and paths"""
     from src.praxxis.sqlite import connection
     

--- a/src/praxxis/sqlite/sqlite_rulesengine.py
+++ b/src/praxxis/sqlite/sqlite_rulesengine.py
@@ -79,7 +79,7 @@ def get_ruleset_by_ord(rulesengine_db, ordinal):
         raise error.RulesetNotFoundError(ordinal)
     return rows[0][0]
 
-def get_all_rulesets(rulesengine_db, query_start, end):
+def get_all_rulesets(rulesengine_db, query_start, query_end):
     """gets all rulesets"""
     from src.praxxis.sqlite import connection
     
@@ -93,7 +93,7 @@ def get_all_rulesets(rulesengine_db, query_start, end):
 
     return rows
 
-def get_active_rulesets(rulesengine_db, query_start, end):
+def get_active_rulesets(rulesengine_db, query_start, query_end):
     """gets all active rulesets and paths"""
     from src.praxxis.sqlite import connection
     

--- a/tests/src/conftest.py
+++ b/tests/src/conftest.py
@@ -3,7 +3,7 @@ imports fixtures from the fixtures db so that they can be used by pytest
 """
 
 import pytest
-from tests.src.praxxis.fixtures.set_roots import init_root, library_root, telemetry_db, library_db, output_root, scene_root, history_db, default_scene_name, current_scene_db, ads_location, rulesengine_root, rulesengine_db, model_root, model_db, query_start, stop, git_root
+from tests.src.praxxis.fixtures.set_roots import init_root, library_root, telemetry_db, library_db, output_root, scene_root, history_db, default_scene_name, current_scene_db, ads_location, rulesengine_root, rulesengine_db, model_root, model_db, query_start, query_end, git_root
 from tests.src.praxxis.fixtures.setup import setup
 from tests.src.praxxis.fixtures.setup_library import notebooks_list, libraries_list, add_test_library
 from tests.src.praxxis.fixtures.set_test_params import set_many_params, set_one_param

--- a/tests/src/conftest.py
+++ b/tests/src/conftest.py
@@ -3,7 +3,7 @@ imports fixtures from the fixtures db so that they can be used by pytest
 """
 
 import pytest
-from tests.src.praxxis.fixtures.set_roots import init_root, library_root, telemetry_db, library_db, output_root, scene_root, history_db, default_scene_name, current_scene_db, ads_location, rulesengine_root, rulesengine_db, model_root, model_db, start, stop, git_root
+from tests.src.praxxis.fixtures.set_roots import init_root, library_root, telemetry_db, library_db, output_root, scene_root, history_db, default_scene_name, current_scene_db, ads_location, rulesengine_root, rulesengine_db, model_root, model_db, query_start, stop, git_root
 from tests.src.praxxis.fixtures.setup import setup
 from tests.src.praxxis.fixtures.setup_library import notebooks_list, libraries_list, add_test_library
 from tests.src.praxxis.fixtures.set_test_params import set_many_params, set_one_param

--- a/tests/src/praxxis/entrypoints/test_entry_library.py
+++ b/tests/src/praxxis/entrypoints/test_entry_library.py
@@ -17,22 +17,22 @@ def test_init_library(setup, library_root, library_db):
     assert os.path.exists(library_db)
 
 
-def test_sync_library(setup, library_root, library_db, query_start, stop):
+def test_sync_library(setup, library_root, library_db, query_start, query_end):
     from src.praxxis.library import list_library
 
     entry_library.sync_library("", library_root, library_db)
-    libraries = list_library.list_library(library_db, query_start, stop)
+    libraries = list_library.list_library(library_db, query_start, query_end)
     assert len(libraries) == 0
 
 
-def test_list_library(setup, add_test_library, library_db, query_start, stop):
+def test_list_library(setup, add_test_library, library_db, query_start, query_end):
     from src.praxxis.library import list_library
     entry_library.list_library("", library_db)
-    assert len(list_library.list_library(library_db, query_start, stop)) == 1
+    assert len(list_library.list_library(library_db, query_start, query_end)) == 1
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="will fail test on windows until git integration is merged")
-def test_add_library(setup, library_db, query_start, stop): 
+def test_add_library(setup, library_db, query_start, query_end): 
     from src.praxxis.util import error
     from tests.src.praxxis.util import dummy_object
     from src.praxxis.library import remove_library
@@ -40,6 +40,6 @@ def test_add_library(setup, library_db, query_start, stop):
 
     dummy_library = dummy_object.make_dummy_library_path()
     entry_library.add_library(dummy_library, library_db)
-    assert len(list_library.list_library(library_db, query_start, stop)) == 1
+    assert len(list_library.list_library(library_db, query_start, query_end)) == 1
 
-    remove_library.remove_library(dummy_library, library_db, query_start, stop)
+    remove_library.remove_library(dummy_library, library_db, query_start, query_end)

--- a/tests/src/praxxis/entrypoints/test_entry_library.py
+++ b/tests/src/praxxis/entrypoints/test_entry_library.py
@@ -17,22 +17,22 @@ def test_init_library(setup, library_root, library_db):
     assert os.path.exists(library_db)
 
 
-def test_sync_library(setup, library_root, library_db, start, stop):
+def test_sync_library(setup, library_root, library_db, query_start, stop):
     from src.praxxis.library import list_library
 
     entry_library.sync_library("", library_root, library_db)
-    libraries = list_library.list_library(library_db, start, stop)
+    libraries = list_library.list_library(library_db, query_start, stop)
     assert len(libraries) == 0
 
 
-def test_list_library(setup, add_test_library, library_db, start, stop):
+def test_list_library(setup, add_test_library, library_db, query_start, stop):
     from src.praxxis.library import list_library
     entry_library.list_library("", library_db)
-    assert len(list_library.list_library(library_db, start, stop)) == 1
+    assert len(list_library.list_library(library_db, query_start, stop)) == 1
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="will fail test on windows until git integration is merged")
-def test_add_library(setup, library_db ,start, stop): 
+def test_add_library(setup, library_db, query_start, stop): 
     from src.praxxis.util import error
     from tests.src.praxxis.util import dummy_object
     from src.praxxis.library import remove_library
@@ -40,6 +40,6 @@ def test_add_library(setup, library_db ,start, stop):
 
     dummy_library = dummy_object.make_dummy_library_path()
     entry_library.add_library(dummy_library, library_db)
-    assert len(list_library.list_library(library_db, start, stop)) == 1
+    assert len(list_library.list_library(library_db, query_start, stop)) == 1
 
-    remove_library.remove_library(dummy_library, library_db, start, stop)
+    remove_library.remove_library(dummy_library, library_db, query_start, stop)

--- a/tests/src/praxxis/entrypoints/test_entry_notebook.py
+++ b/tests/src/praxxis/entrypoints/test_entry_notebook.py
@@ -19,20 +19,20 @@ def test_next_notebook():
     assert entry_notebook.next_notebook(notebook) == "coming soon"
 """
 
-def test_list_notebook(setup, add_test_library, scene_root, history_db, library_root, library_db, start, stop, current_scene_db):
+def test_list_notebook(setup, add_test_library, scene_root, history_db, library_root, library_db, query_start, stop, current_scene_db):
     from src.praxxis.notebook import list_notebook
     notebook = dummy_object.make_dummy_notebook()
 
-    entry_notebook.list_notebook(notebook, scene_root, history_db, library_root, library_db, start, stop, current_scene_db)
-    assert len(list_notebook.list_notebook(library_db,current_scene_db, start, stop)) == 3
+    entry_notebook.list_notebook(notebook, scene_root, history_db, library_root, library_db, query_start, stop, current_scene_db)
+    assert len(list_notebook.list_notebook(library_db,current_scene_db, query_start, stop)) == 3
 
 
-def test_search_notebook(setup, add_test_library, scene_root, history_db, library_db, start, stop, current_scene_db):
+def test_search_notebook(setup, add_test_library, scene_root, history_db, library_db, query_start, stop, current_scene_db):
     from src.praxxis.notebook import search_notebook
     search = dummy_object.make_dummy_search()
 
-    entry_notebook.search_notebook(search, scene_root, history_db, library_db, start, stop, current_scene_db)
-    notebooks = search_notebook.search_notebook(search, library_db, current_scene_db, start, stop)
+    entry_notebook.search_notebook(search, scene_root, history_db, library_db, query_start, stop, current_scene_db)
+    notebooks = search_notebook.search_notebook(search, library_db, current_scene_db, query_start, stop)
     assert len(notebooks) == 2
 
 

--- a/tests/src/praxxis/entrypoints/test_entry_notebook.py
+++ b/tests/src/praxxis/entrypoints/test_entry_notebook.py
@@ -19,20 +19,20 @@ def test_next_notebook():
     assert entry_notebook.next_notebook(notebook) == "coming soon"
 """
 
-def test_list_notebook(setup, add_test_library, scene_root, history_db, library_root, library_db, query_start, stop, current_scene_db):
+def test_list_notebook(setup, add_test_library, scene_root, history_db, library_root, library_db, query_start, query_end, current_scene_db):
     from src.praxxis.notebook import list_notebook
     notebook = dummy_object.make_dummy_notebook()
 
-    entry_notebook.list_notebook(notebook, scene_root, history_db, library_root, library_db, query_start, stop, current_scene_db)
-    assert len(list_notebook.list_notebook(library_db,current_scene_db, query_start, stop)) == 3
+    entry_notebook.list_notebook(notebook, scene_root, history_db, library_root, library_db, query_start, query_end, current_scene_db)
+    assert len(list_notebook.list_notebook(library_db,current_scene_db, query_start, query_end)) == 3
 
 
-def test_search_notebook(setup, add_test_library, scene_root, history_db, library_db, query_start, stop, current_scene_db):
+def test_search_notebook(setup, add_test_library, scene_root, history_db, library_db, query_start, query_end, current_scene_db):
     from src.praxxis.notebook import search_notebook
     search = dummy_object.make_dummy_search()
 
-    entry_notebook.search_notebook(search, scene_root, history_db, library_db, query_start, stop, current_scene_db)
-    notebooks = search_notebook.search_notebook(search, library_db, current_scene_db, query_start, stop)
+    entry_notebook.search_notebook(search, scene_root, history_db, library_db, query_start, query_end, current_scene_db)
+    notebooks = search_notebook.search_notebook(search, library_db, current_scene_db, query_start, query_end)
     assert len(notebooks) == 2
 
 

--- a/tests/src/praxxis/entrypoints/test_entry_parameter.py
+++ b/tests/src/praxxis/entrypoints/test_entry_parameter.py
@@ -1,28 +1,28 @@
 from src.praxxis.entrypoints import entry_parameter
 from tests.src.praxxis.util import dummy_object
 
-def test_view_library_param(setup, add_test_library, scene_root, history_db, library_db, current_scene_db, query_start, stop):
+def test_view_library_param(setup, add_test_library, scene_root, history_db, library_db, current_scene_db, query_start, query_end):
     from src.praxxis.parameter import list_param
 
-    library_params = list_param.list_library_param("test_notebooks", library_db, current_scene_db, query_start, stop)
+    library_params = list_param.list_library_param("test_notebooks", library_db, current_scene_db, query_start, query_end)
     params = dummy_object.make_dummy_params()
 
     entry_parameter.view_library_param("test_notebooks", scene_root, history_db, library_db, current_scene_db)
     assert params.parameter == library_params
 
 
-def test_list_param(setup, set_one_param, scene_root, history_db, query_start, stop, current_scene_db):
+def test_list_param(setup, set_one_param, scene_root, history_db, query_start, query_end, current_scene_db):
     from src.praxxis.parameter import list_param
-    entry_parameter.list_param("", scene_root, history_db, query_start, stop, current_scene_db)
+    entry_parameter.list_param("", scene_root, history_db, query_start, query_end, current_scene_db)
     
-    assert len(list_param.list_param(current_scene_db, query_start, stop)) == 1
+    assert len(list_param.list_param(current_scene_db, query_start, query_end)) == 1
 
 
-def test_delete_param(setup, set_one_param, scene_root, history_db, current_scene_db, query_start, stop):
+def test_delete_param(setup, set_one_param, scene_root, history_db, current_scene_db, query_start, query_end):
     from src.praxxis.parameter import list_param
 
     entry_parameter.delete_param("generated_single_param", scene_root, history_db, current_scene_db)
-    assert len(list_param.list_param(current_scene_db, query_start, stop)) == 0
+    assert len(list_param.list_param(current_scene_db, query_start, query_end)) == 0
 
 def test_set_param(setup, scene_root, history_db, current_scene_db):
     from src.praxxis.parameter import delete_param
@@ -39,7 +39,7 @@ def test_set_param(setup, scene_root, history_db, current_scene_db):
         assert 1
 
 
-def test_view_notebook_param(setup, add_test_library, scene_root, library_db, history_db, current_scene_db, query_start, stop):
+def test_view_notebook_param(setup, add_test_library, scene_root, library_db, history_db, current_scene_db, query_start, query_end):
     import os
     from src.praxxis.parameter import list_param
 

--- a/tests/src/praxxis/entrypoints/test_entry_parameter.py
+++ b/tests/src/praxxis/entrypoints/test_entry_parameter.py
@@ -1,28 +1,28 @@
 from src.praxxis.entrypoints import entry_parameter
 from tests.src.praxxis.util import dummy_object
 
-def test_view_library_param(setup, add_test_library, scene_root, history_db, library_db, current_scene_db, start, stop):
+def test_view_library_param(setup, add_test_library, scene_root, history_db, library_db, current_scene_db, query_start, stop):
     from src.praxxis.parameter import list_param
 
-    library_params = list_param.list_library_param("test_notebooks", library_db, current_scene_db, start, stop)
+    library_params = list_param.list_library_param("test_notebooks", library_db, current_scene_db, query_start, stop)
     params = dummy_object.make_dummy_params()
 
     entry_parameter.view_library_param("test_notebooks", scene_root, history_db, library_db, current_scene_db)
     assert params.parameter == library_params
 
 
-def test_list_param(setup, set_one_param, scene_root, history_db, start, stop, current_scene_db):
+def test_list_param(setup, set_one_param, scene_root, history_db, query_start, stop, current_scene_db):
     from src.praxxis.parameter import list_param
-    entry_parameter.list_param("", scene_root, history_db, start, stop, current_scene_db)
+    entry_parameter.list_param("", scene_root, history_db, query_start, stop, current_scene_db)
     
-    assert len(list_param.list_param(current_scene_db, start, stop)) == 1
+    assert len(list_param.list_param(current_scene_db, query_start, stop)) == 1
 
 
-def test_delete_param(setup, set_one_param, scene_root, history_db, current_scene_db, start, stop):
+def test_delete_param(setup, set_one_param, scene_root, history_db, current_scene_db, query_start, stop):
     from src.praxxis.parameter import list_param
 
     entry_parameter.delete_param("generated_single_param", scene_root, history_db, current_scene_db)
-    assert len(list_param.list_param(current_scene_db, start, stop)) == 0
+    assert len(list_param.list_param(current_scene_db, query_start, stop)) == 0
 
 def test_set_param(setup, scene_root, history_db, current_scene_db):
     from src.praxxis.parameter import delete_param
@@ -39,7 +39,7 @@ def test_set_param(setup, scene_root, history_db, current_scene_db):
         assert 1
 
 
-def test_view_notebook_param(setup, add_test_library, scene_root, library_db, history_db, current_scene_db, start, stop):
+def test_view_notebook_param(setup, add_test_library, scene_root, library_db, history_db, current_scene_db, query_start, stop):
     import os
     from src.praxxis.parameter import list_param
 

--- a/tests/src/praxxis/entrypoints/test_entry_rulesengine.py
+++ b/tests/src/praxxis/entrypoints/test_entry_rulesengine.py
@@ -23,7 +23,7 @@ def test_new_ruleset(setup, rulesengine_root, rulesengine_db):
     entry_rulesengine.new_ruleset(name1, rulesengine_root, rulesengine_db)
 
     from src.praxxis.sqlite import sqlite_rulesengine
-    ruleset_list = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start=1, end=10)
+    ruleset_list = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start=1, query_end=10)
 
     assert ruleset_list[0][0] == name1.name
     
@@ -34,12 +34,12 @@ def test_remove_ruleset(setup, rulesengine_root, rulesengine_db, create_one_rule
     name1 = dummy_object.make_dummy_ruleset("generated_one_ruleset")
 
     from src.praxxis.sqlite import sqlite_rulesengine
-    ruleset_list = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start=1, end=10)
+    ruleset_list = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start=1, query_end=10)
 
     assert ruleset_list[0][0] == name1.name
     entry_rulesengine.remove_ruleset(name1, rulesengine_db)
     
-    ruleset_list = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start=1, end=10)
+    ruleset_list = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start=1, query_end=10)
 
     assert len(ruleset_list) == 0
     

--- a/tests/src/praxxis/entrypoints/test_entry_rulesengine.py
+++ b/tests/src/praxxis/entrypoints/test_entry_rulesengine.py
@@ -23,7 +23,7 @@ def test_new_ruleset(setup, rulesengine_root, rulesengine_db):
     entry_rulesengine.new_ruleset(name1, rulesengine_root, rulesengine_db)
 
     from src.praxxis.sqlite import sqlite_rulesengine
-    ruleset_list = sqlite_rulesengine.get_all_rulesets(rulesengine_db, start=1, end=10)
+    ruleset_list = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start=1, end=10)
 
     assert ruleset_list[0][0] == name1.name
     
@@ -34,12 +34,12 @@ def test_remove_ruleset(setup, rulesengine_root, rulesengine_db, create_one_rule
     name1 = dummy_object.make_dummy_ruleset("generated_one_ruleset")
 
     from src.praxxis.sqlite import sqlite_rulesengine
-    ruleset_list = sqlite_rulesengine.get_all_rulesets(rulesengine_db, start=1, end=10)
+    ruleset_list = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start=1, end=10)
 
     assert ruleset_list[0][0] == name1.name
     entry_rulesengine.remove_ruleset(name1, rulesengine_db)
     
-    ruleset_list = sqlite_rulesengine.get_all_rulesets(rulesengine_db, start=1, end=10)
+    ruleset_list = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start=1, end=10)
 
     assert len(ruleset_list) == 0
     

--- a/tests/src/praxxis/fixtures/set_roots.py
+++ b/tests/src/praxxis/fixtures/set_roots.py
@@ -123,7 +123,7 @@ def git_root(library_root):
 
 
 @pytest.fixture(scope="session")
-def start():
+def query_start():
     return 0
 
 

--- a/tests/src/praxxis/fixtures/set_roots.py
+++ b/tests/src/praxxis/fixtures/set_roots.py
@@ -128,6 +128,6 @@ def query_start():
 
 
 @pytest.fixture(scope="session")
-def stop():
+def query_end():
     return 100
 

--- a/tests/src/praxxis/fixtures/setup.py
+++ b/tests/src/praxxis/fixtures/setup.py
@@ -5,7 +5,7 @@ import pytest
 import os
 
 @pytest.fixture(scope="session")
-def setup(init_root, library_root, telemetry_db, library_db, output_root, scene_root, history_db, default_scene_name, start, stop, rulesengine_root, rulesengine_db):
+def setup(init_root, library_root, telemetry_db, library_db, output_root, scene_root, history_db, default_scene_name, query_start, stop, rulesengine_root, rulesengine_db):
     """
     sets up directories in the temp dir
     """
@@ -63,7 +63,7 @@ def setup(init_root, library_root, telemetry_db, library_db, output_root, scene_
     yield 
     current_scene_db = roots.get_current_scene_db(scene_root, history_db)
     assert len(list_scene.list_scene(init_root, history_db)) == 1
-    assert len(list_param.list_param(current_scene_db, start, stop)) == 0
-    assert len(list_library.list_library(library_db, start, stop)) == 0
-    assert len(list_notebook.list_notebook(library_db, current_scene_db, start, stop)) == 0
+    assert len(list_param.list_param(current_scene_db, query_start, stop)) == 0
+    assert len(list_library.list_library(library_db, query_start, stop)) == 0
+    assert len(list_notebook.list_notebook(library_db, current_scene_db, query_start, stop)) == 0
     

--- a/tests/src/praxxis/fixtures/setup.py
+++ b/tests/src/praxxis/fixtures/setup.py
@@ -5,7 +5,7 @@ import pytest
 import os
 
 @pytest.fixture(scope="session")
-def setup(init_root, library_root, telemetry_db, library_db, output_root, scene_root, history_db, default_scene_name, query_start, stop, rulesengine_root, rulesengine_db):
+def setup(init_root, library_root, telemetry_db, library_db, output_root, scene_root, history_db, default_scene_name, query_start, query_end, rulesengine_root, rulesengine_db):
     """
     sets up directories in the temp dir
     """
@@ -63,7 +63,7 @@ def setup(init_root, library_root, telemetry_db, library_db, output_root, scene_
     yield 
     current_scene_db = roots.get_current_scene_db(scene_root, history_db)
     assert len(list_scene.list_scene(init_root, history_db)) == 1
-    assert len(list_param.list_param(current_scene_db, query_start, stop)) == 0
-    assert len(list_library.list_library(library_db, query_start, stop)) == 0
-    assert len(list_notebook.list_notebook(library_db, current_scene_db, query_start, stop)) == 0
+    assert len(list_param.list_param(current_scene_db, query_start, query_end)) == 0
+    assert len(list_library.list_library(library_db, query_start, query_end)) == 0
+    assert len(list_notebook.list_notebook(library_db, current_scene_db, query_start, query_end)) == 0
     

--- a/tests/src/praxxis/fixtures/setup_library.py
+++ b/tests/src/praxxis/fixtures/setup_library.py
@@ -4,7 +4,7 @@ adds test library to temp directories and does a few useful operations on them
 import pytest
 
 @pytest.fixture(scope="function")
-def add_test_library(library_root, library_db, start, stop):
+def add_test_library(library_root, library_db, query_start, stop):
     """
     copies test notebooks from the tests directory to the temp root, and loads them into the db
     """
@@ -25,7 +25,7 @@ def add_test_library(library_root, library_db, start, stop):
     yield 
 
     dummy_library = dummy_object.make_dummy_library()
-    remove_library.remove_library(dummy_library, library_db, start, stop)
+    remove_library.remove_library(dummy_library, library_db, query_start, stop)
     rmtree.rmtree(library_location, test=True)
 
 

--- a/tests/src/praxxis/fixtures/setup_library.py
+++ b/tests/src/praxxis/fixtures/setup_library.py
@@ -4,7 +4,7 @@ adds test library to temp directories and does a few useful operations on them
 import pytest
 
 @pytest.fixture(scope="function")
-def add_test_library(library_root, library_db, query_start, stop):
+def add_test_library(library_root, library_db, query_start, query_end):
     """
     copies test notebooks from the tests directory to the temp root, and loads them into the db
     """
@@ -25,7 +25,7 @@ def add_test_library(library_root, library_db, query_start, stop):
     yield 
 
     dummy_library = dummy_object.make_dummy_library()
-    remove_library.remove_library(dummy_library, library_db, query_start, stop)
+    remove_library.remove_library(dummy_library, library_db, query_start, query_end)
     rmtree.rmtree(library_location, test=True)
 
 

--- a/tests/src/praxxis/fixtures/setup_scenes.py
+++ b/tests/src/praxxis/fixtures/setup_scenes.py
@@ -57,13 +57,13 @@ def create_ended_scene(scene_root, history_db, current_scene_db):
 
 
 @pytest.fixture(scope="function")
-def generate_short_history(setup, add_test_library, telemetry_db, output_root, current_scene_db, library_root, library_db, start, stop):
+def generate_short_history(setup, add_test_library, telemetry_db, output_root, current_scene_db, library_root, library_db, query_start, stop):
     from src.praxxis.notebook import run_notebook
     from tests.src.praxxis.util import dummy_object
     from src.praxxis.sqlite import sqlite_scene
     import os
 
     notebook1 = dummy_object.make_dummy_notebook()
-    run_notebook.run_notebook(notebook1, telemetry_db, output_root, current_scene_db, library_root, library_db, start, stop)
+    run_notebook.run_notebook(notebook1, telemetry_db, output_root, current_scene_db, library_root, library_db, query_start, stop)
     yield 
     sqlite_scene.clear_history(current_scene_db)

--- a/tests/src/praxxis/fixtures/setup_scenes.py
+++ b/tests/src/praxxis/fixtures/setup_scenes.py
@@ -57,13 +57,13 @@ def create_ended_scene(scene_root, history_db, current_scene_db):
 
 
 @pytest.fixture(scope="function")
-def generate_short_history(setup, add_test_library, telemetry_db, output_root, current_scene_db, library_root, library_db, query_start, stop):
+def generate_short_history(setup, add_test_library, telemetry_db, output_root, current_scene_db, library_root, library_db, query_start, query_end):
     from src.praxxis.notebook import run_notebook
     from tests.src.praxxis.util import dummy_object
     from src.praxxis.sqlite import sqlite_scene
     import os
 
     notebook1 = dummy_object.make_dummy_notebook()
-    run_notebook.run_notebook(notebook1, telemetry_db, output_root, current_scene_db, library_root, library_db, query_start, stop)
+    run_notebook.run_notebook(notebook1, telemetry_db, output_root, current_scene_db, library_root, library_db, query_start, query_end)
     yield 
     sqlite_scene.clear_history(current_scene_db)

--- a/tests/src/praxxis/library/test_add_library.py
+++ b/tests/src/praxxis/library/test_add_library.py
@@ -1,6 +1,6 @@
 import pytest
 
-def test_add_regular_library(setup, library_db, git_root, query_start, stop):
+def test_add_regular_library(setup, library_db, git_root, query_start, query_end):
     from src.praxxis.library import add_library
     from src.praxxis.library import list_library
     from src.praxxis.library import remove_library
@@ -11,14 +11,14 @@ def test_add_regular_library(setup, library_db, git_root, query_start, stop):
 
     add_library.add_library(library_path, library_db, git_root)
 
-    libraries = list_library.list_library(library_db, query_start, stop)
+    libraries = list_library.list_library(library_db, query_start, query_end)
     assert len(libraries) == 1
-    remove_library.remove_library(library, library_db, query_start, stop)
-    libraries = list_library.list_library(library_db, query_start, stop)
+    remove_library.remove_library(library, library_db, query_start, query_end)
+    libraries = list_library.list_library(library_db, query_start, query_end)
     assert len(libraries) == 0
 
 @pytest.mark.skip(reason="need to decide on a good git repo to test this on ")
-def test_add_git_library(setup, library_db, git_root, query_start, stop):
+def test_add_git_library(setup, library_db, git_root, query_start, query_end):
     from src.praxxis.library import add_library
     from src.praxxis.library import remove_library
     from src.praxxis.library import list_library
@@ -28,16 +28,16 @@ def test_add_git_library(setup, library_db, git_root, query_start, stop):
     url = dummy_object.make_dummy_git_repo()
     add_library.add_library(url, library_db, git_root)
 
-    libraries = list_library.list_library(library_db, query_start, stop)
+    libraries = list_library.list_library(library_db, query_start, query_end)
     assert len(libraries) == 1
-    remove_library.remove_library(url, library_db, query_start, stop)
-    libraries = list_library.list_library(library_db, query_start, stop)
+    remove_library.remove_library(url, library_db, query_start, query_end)
+    libraries = list_library.list_library(library_db, query_start, query_end)
 
     assert len(libraries) == 0
     rmtree.rmtree(git_root, test=True)
 
 
-def test_add_bad_library(setup, library_db, git_root, query_start, stop):
+def test_add_bad_library(setup, library_db, git_root, query_start, query_end):
     from src.praxxis.library import add_library
     from tests.src.praxxis.util import dummy_object
     from src.praxxis.util import error

--- a/tests/src/praxxis/library/test_add_library.py
+++ b/tests/src/praxxis/library/test_add_library.py
@@ -1,6 +1,6 @@
 import pytest
 
-def test_add_regular_library(setup, library_db, git_root, start, stop):
+def test_add_regular_library(setup, library_db, git_root, query_start, stop):
     from src.praxxis.library import add_library
     from src.praxxis.library import list_library
     from src.praxxis.library import remove_library
@@ -11,14 +11,14 @@ def test_add_regular_library(setup, library_db, git_root, start, stop):
 
     add_library.add_library(library_path, library_db, git_root)
 
-    libraries = list_library.list_library(library_db, start, stop)
+    libraries = list_library.list_library(library_db, query_start, stop)
     assert len(libraries) == 1
-    remove_library.remove_library(library, library_db, start, stop)
-    libraries = list_library.list_library(library_db, start, stop)
+    remove_library.remove_library(library, library_db, query_start, stop)
+    libraries = list_library.list_library(library_db, query_start, stop)
     assert len(libraries) == 0
 
 @pytest.mark.skip(reason="need to decide on a good git repo to test this on ")
-def test_add_git_library(setup, library_db, git_root, start, stop):
+def test_add_git_library(setup, library_db, git_root, query_start, stop):
     from src.praxxis.library import add_library
     from src.praxxis.library import remove_library
     from src.praxxis.library import list_library
@@ -28,16 +28,16 @@ def test_add_git_library(setup, library_db, git_root, start, stop):
     url = dummy_object.make_dummy_git_repo()
     add_library.add_library(url, library_db, git_root)
 
-    libraries = list_library.list_library(library_db, start, stop)
+    libraries = list_library.list_library(library_db, query_start, stop)
     assert len(libraries) == 1
-    remove_library.remove_library(url, library_db, start, stop)
-    libraries = list_library.list_library(library_db, start, stop)
+    remove_library.remove_library(url, library_db, query_start, stop)
+    libraries = list_library.list_library(library_db, query_start, stop)
 
     assert len(libraries) == 0
     rmtree.rmtree(git_root, test=True)
 
 
-def test_add_bad_library(setup, library_db, git_root, start, stop):
+def test_add_bad_library(setup, library_db, git_root, query_start, stop):
     from src.praxxis.library import add_library
     from tests.src.praxxis.util import dummy_object
     from src.praxxis.util import error

--- a/tests/src/praxxis/library/test_sync_library.py
+++ b/tests/src/praxxis/library/test_sync_library.py
@@ -4,7 +4,7 @@ this tests the sync library functionality of praxxis
 
 import pytest 
 
-def test_sync_library(setup, add_test_library, library_root, library_db, libraries_list, query_start, stop):
+def test_sync_library(setup, add_test_library, library_root, library_db, libraries_list, query_start, query_end):
     """
     tests sync_library functionality. Requires that setup is run and the test notebooks are added.
     """
@@ -15,4 +15,4 @@ def test_sync_library(setup, add_test_library, library_root, library_db, librari
 
     sync_library.sync_library(library_root, library_db)
         
-    assert set(libraries_list) == set(*list_library.list_library(library_db, query_start, stop))
+    assert set(libraries_list) == set(*list_library.list_library(library_db, query_start, query_end))

--- a/tests/src/praxxis/library/test_sync_library.py
+++ b/tests/src/praxxis/library/test_sync_library.py
@@ -4,7 +4,7 @@ this tests the sync library functionality of praxxis
 
 import pytest 
 
-def test_sync_library(setup, add_test_library, library_root, library_db, libraries_list, start, stop):
+def test_sync_library(setup, add_test_library, library_root, library_db, libraries_list, query_start, stop):
     """
     tests sync_library functionality. Requires that setup is run and the test notebooks are added.
     """
@@ -15,4 +15,4 @@ def test_sync_library(setup, add_test_library, library_root, library_db, librari
 
     sync_library.sync_library(library_root, library_db)
         
-    assert set(libraries_list) == set(*list_library.list_library(library_db, start, stop))
+    assert set(libraries_list) == set(*list_library.list_library(library_db, query_start, stop))

--- a/tests/src/praxxis/notebook/test_add_notebook.py
+++ b/tests/src/praxxis/notebook/test_add_notebook.py
@@ -1,4 +1,4 @@
-def test_add_notebook(setup, library_db, current_scene_db, start, stop):
+def test_add_notebook(setup, library_db, current_scene_db, query_start, stop):
     from src.praxxis.notebook import add_notebook
     from src.praxxis.notebook import remove_notebook
     from tests.src.praxxis.util import dummy_object
@@ -8,7 +8,7 @@ def test_add_notebook(setup, library_db, current_scene_db, start, stop):
     dummy_notebook = dummy_object.make_dummy_notebook()
 
     add_notebook.add_notebook(dummy_notebook_path, library_db)
-    assert len(list_notebook.list_notebook(library_db, current_scene_db, start, stop)) == 1
+    assert len(list_notebook.list_notebook(library_db, current_scene_db, query_start, stop)) == 1
 
     remove_notebook.remove_notebook(dummy_notebook, library_db, current_scene_db)
-    assert len(list_notebook.list_notebook(library_db, current_scene_db, start, stop)) == 0
+    assert len(list_notebook.list_notebook(library_db, current_scene_db, query_start, stop)) == 0

--- a/tests/src/praxxis/notebook/test_add_notebook.py
+++ b/tests/src/praxxis/notebook/test_add_notebook.py
@@ -1,4 +1,4 @@
-def test_add_notebook(setup, library_db, current_scene_db, query_start, stop):
+def test_add_notebook(setup, library_db, current_scene_db, query_start, query_end):
     from src.praxxis.notebook import add_notebook
     from src.praxxis.notebook import remove_notebook
     from tests.src.praxxis.util import dummy_object
@@ -8,7 +8,7 @@ def test_add_notebook(setup, library_db, current_scene_db, query_start, stop):
     dummy_notebook = dummy_object.make_dummy_notebook()
 
     add_notebook.add_notebook(dummy_notebook_path, library_db)
-    assert len(list_notebook.list_notebook(library_db, current_scene_db, query_start, stop)) == 1
+    assert len(list_notebook.list_notebook(library_db, current_scene_db, query_start, query_end)) == 1
 
     remove_notebook.remove_notebook(dummy_notebook, library_db, current_scene_db)
-    assert len(list_notebook.list_notebook(library_db, current_scene_db, query_start, stop)) == 0
+    assert len(list_notebook.list_notebook(library_db, current_scene_db, query_start, query_end)) == 0

--- a/tests/src/praxxis/notebook/test_list_notebooks.py
+++ b/tests/src/praxxis/notebook/test_list_notebooks.py
@@ -6,17 +6,17 @@ import pytest
 
 from tests.src.praxxis.fixtures.setup_library import add_test_library
 
-def test_list_notebooks_empty(setup, library_db, current_scene_db, start, stop):
+def test_list_notebooks_empty(setup, library_db, current_scene_db, query_start, stop):
     """ tests listing notebooks when no libraries exist """
     import os
     from src.praxxis.notebook import list_notebook
     from src.praxxis.scene import current_scene
-    notebooks = list_notebook.list_notebook(library_db, current_scene_db, start, stop)
+    notebooks = list_notebook.list_notebook(library_db, current_scene_db, query_start, stop)
     assert notebooks == []
 
 
-def test_list_notebooks_populated(setup, add_test_library, library_db, current_scene_db, start, stop, notebooks_list):
+def test_list_notebooks_populated(setup, add_test_library, library_db, current_scene_db, query_start, stop, notebooks_list):
     from src.praxxis.notebook import list_notebook
     
-    notebooks = list_notebook.list_notebook(library_db, current_scene_db, start, stop)
+    notebooks = list_notebook.list_notebook(library_db, current_scene_db, query_start, stop)
     assert len(notebooks) == len(notebooks_list)

--- a/tests/src/praxxis/notebook/test_list_notebooks.py
+++ b/tests/src/praxxis/notebook/test_list_notebooks.py
@@ -6,17 +6,17 @@ import pytest
 
 from tests.src.praxxis.fixtures.setup_library import add_test_library
 
-def test_list_notebooks_empty(setup, library_db, current_scene_db, query_start, stop):
+def test_list_notebooks_empty(setup, library_db, current_scene_db, query_start, query_end):
     """ tests listing notebooks when no libraries exist """
     import os
     from src.praxxis.notebook import list_notebook
     from src.praxxis.scene import current_scene
-    notebooks = list_notebook.list_notebook(library_db, current_scene_db, query_start, stop)
+    notebooks = list_notebook.list_notebook(library_db, current_scene_db, query_start, query_end)
     assert notebooks == []
 
 
-def test_list_notebooks_populated(setup, add_test_library, library_db, current_scene_db, query_start, stop, notebooks_list):
+def test_list_notebooks_populated(setup, add_test_library, library_db, current_scene_db, query_start, query_end, notebooks_list):
     from src.praxxis.notebook import list_notebook
     
-    notebooks = list_notebook.list_notebook(library_db, current_scene_db, query_start, stop)
+    notebooks = list_notebook.list_notebook(library_db, current_scene_db, query_start, query_end)
     assert len(notebooks) == len(notebooks_list)

--- a/tests/src/praxxis/notebook/test_search_notebook.py
+++ b/tests/src/praxxis/notebook/test_search_notebook.py
@@ -1,11 +1,11 @@
-def test_search_notebook(setup, add_test_library, library_db, current_scene_db, start, stop):
+def test_search_notebook(setup, add_test_library, library_db, current_scene_db, query_start, stop):
     import argparse
     from src.praxxis.notebook import search_notebook
     from tests.src.praxxis.util import dummy_object
 
     term = dummy_object.make_dummy_search()
 
-    notebooks = search_notebook.search_notebook(term, library_db, current_scene_db, start, stop)
+    notebooks = search_notebook.search_notebook(term, library_db, current_scene_db, query_start, stop)
     assert len(notebooks) == 2
 
 

--- a/tests/src/praxxis/notebook/test_search_notebook.py
+++ b/tests/src/praxxis/notebook/test_search_notebook.py
@@ -1,11 +1,11 @@
-def test_search_notebook(setup, add_test_library, library_db, current_scene_db, query_start, stop):
+def test_search_notebook(setup, add_test_library, library_db, current_scene_db, query_start, query_end):
     import argparse
     from src.praxxis.notebook import search_notebook
     from tests.src.praxxis.util import dummy_object
 
     term = dummy_object.make_dummy_search()
 
-    notebooks = search_notebook.search_notebook(term, library_db, current_scene_db, query_start, stop)
+    notebooks = search_notebook.search_notebook(term, library_db, current_scene_db, query_start, query_end)
     assert len(notebooks) == 2
 
 

--- a/tests/src/praxxis/notebook/test_what_next.py
+++ b/tests/src/praxxis/notebook/test_what_next.py
@@ -1,11 +1,11 @@
 import pytest
 
 def test_what_next_rulesengine(setup, telemetry_db, current_scene_db, 
-        library_db, rulesengine_db, start, stop, generate_short_history,
+        library_db, rulesengine_db, query_start, stop, generate_short_history,
         create_one_ruleset_one_rule):
     from src.praxxis.notebook import what_next
 
-    predictions = what_next.what_next("", telemetry_db, current_scene_db, library_db, rulesengine_db, start, stop)
+    predictions = what_next.what_next("", telemetry_db, current_scene_db, library_db, rulesengine_db, query_start, stop)
 
     assert len(predictions) == 2
     assert predictions[0][0] == "pred1"

--- a/tests/src/praxxis/notebook/test_what_next.py
+++ b/tests/src/praxxis/notebook/test_what_next.py
@@ -1,11 +1,11 @@
 import pytest
 
 def test_what_next_rulesengine(setup, telemetry_db, current_scene_db, 
-        library_db, rulesengine_db, query_start, stop, generate_short_history,
+        library_db, rulesengine_db, query_start, query_end, generate_short_history,
         create_one_ruleset_one_rule):
     from src.praxxis.notebook import what_next
 
-    predictions = what_next.what_next("", telemetry_db, current_scene_db, library_db, rulesengine_db, query_start, stop)
+    predictions = what_next.what_next("", telemetry_db, current_scene_db, library_db, rulesengine_db, query_start, query_end)
 
     assert len(predictions) == 2
     assert predictions[0][0] == "pred1"

--- a/tests/src/praxxis/parameter/test_delete_param.py
+++ b/tests/src/praxxis/parameter/test_delete_param.py
@@ -1,22 +1,22 @@
 import argparse 
 
-def test_delete_one_param(setup, set_one_param, scene_root, history_db, current_scene_db, query_start, stop):
+def test_delete_one_param(setup, set_one_param, scene_root, history_db, current_scene_db, query_start, query_end):
     from src.praxxis.parameter import delete_param
     from src.praxxis.parameter import list_param
     from tests.src.praxxis.util import dummy_object
 
     name1 = dummy_object.make_dummy_object("generated_single_param")
 
-    result = list_param.list_param(current_scene_db, query_start, stop)
+    result = list_param.list_param(current_scene_db, query_start, query_end)
     assert len(result) == 1
     
     delete_param.delete_parameter(name1, scene_root, history_db, current_scene_db)
-    result = list_param.list_param(current_scene_db, query_start, stop)
+    result = list_param.list_param(current_scene_db, query_start, query_end)
 
     assert result == []
     
 
-def test_delete_many_param(setup, set_many_params, scene_root, history_db, current_scene_db, query_start, stop):
+def test_delete_many_param(setup, set_many_params, scene_root, history_db, current_scene_db, query_start, query_end):
     from src.praxxis.parameter import delete_param
     from src.praxxis.parameter import list_param
     from tests.src.praxxis.util import dummy_object
@@ -24,11 +24,11 @@ def test_delete_many_param(setup, set_many_params, scene_root, history_db, curre
     name1 = dummy_object.make_dummy_object("generated_multiple_param")
     name2 = dummy_object.make_dummy_object("generated_multiple_param1")
 
-    result = list_param.list_param(current_scene_db, query_start, stop)
+    result = list_param.list_param(current_scene_db, query_start, query_end)
     assert len(result) == 2
 
     delete_param.delete_parameter(name1, scene_root, history_db, current_scene_db)
     delete_param.delete_parameter(name2, scene_root, history_db, current_scene_db)
-    result = list_param.list_param(current_scene_db, query_start, stop)
+    result = list_param.list_param(current_scene_db, query_start, query_end)
     assert len(result) == 0
     

--- a/tests/src/praxxis/parameter/test_delete_param.py
+++ b/tests/src/praxxis/parameter/test_delete_param.py
@@ -1,22 +1,22 @@
 import argparse 
 
-def test_delete_one_param(setup, set_one_param, scene_root, history_db, current_scene_db, start, stop):
+def test_delete_one_param(setup, set_one_param, scene_root, history_db, current_scene_db, query_start, stop):
     from src.praxxis.parameter import delete_param
     from src.praxxis.parameter import list_param
     from tests.src.praxxis.util import dummy_object
 
     name1 = dummy_object.make_dummy_object("generated_single_param")
 
-    result = list_param.list_param(current_scene_db, start, stop)
+    result = list_param.list_param(current_scene_db, query_start, stop)
     assert len(result) == 1
     
     delete_param.delete_parameter(name1, scene_root, history_db, current_scene_db)
-    result = list_param.list_param(current_scene_db, start, stop)
+    result = list_param.list_param(current_scene_db, query_start, stop)
 
     assert result == []
     
 
-def test_delete_many_param(setup, set_many_params, scene_root, history_db, current_scene_db, start, stop):
+def test_delete_many_param(setup, set_many_params, scene_root, history_db, current_scene_db, query_start, stop):
     from src.praxxis.parameter import delete_param
     from src.praxxis.parameter import list_param
     from tests.src.praxxis.util import dummy_object
@@ -24,11 +24,11 @@ def test_delete_many_param(setup, set_many_params, scene_root, history_db, curre
     name1 = dummy_object.make_dummy_object("generated_multiple_param")
     name2 = dummy_object.make_dummy_object("generated_multiple_param1")
 
-    result = list_param.list_param(current_scene_db, start, stop)
+    result = list_param.list_param(current_scene_db, query_start, stop)
     assert len(result) == 2
 
     delete_param.delete_parameter(name1, scene_root, history_db, current_scene_db)
     delete_param.delete_parameter(name2, scene_root, history_db, current_scene_db)
-    result = list_param.list_param(current_scene_db, start, stop)
+    result = list_param.list_param(current_scene_db, query_start, stop)
     assert len(result) == 0
     

--- a/tests/src/praxxis/parameter/test_pull_param.py
+++ b/tests/src/praxxis/parameter/test_pull_param.py
@@ -1,11 +1,11 @@
-def test_pull_library_notebook(setup, add_test_library, library_db, current_scene_db, start, stop):
+def test_pull_library_notebook(setup, add_test_library, library_db, current_scene_db, query_start, stop):
     from src.praxxis.parameter import pull_param
     from tests.src.praxxis.util import dummy_object
     from src.praxxis.parameter import list_param
 
     # args = dummy_object.make_dummy_library()
 
-    # params = list_param.list_param(current_scene_db, start, stop)
+    # params = list_param.list_param(current_scene_db, query_start, stop)
     # assert len(params) == 0
     # pull_param.pull_library_parameter(args, library_db, current_scene_db)
     # assert len(params) == 2

--- a/tests/src/praxxis/parameter/test_pull_param.py
+++ b/tests/src/praxxis/parameter/test_pull_param.py
@@ -1,11 +1,11 @@
-def test_pull_library_notebook(setup, add_test_library, library_db, current_scene_db, query_start, stop):
+def test_pull_library_notebook(setup, add_test_library, library_db, current_scene_db, query_start, query_end):
     from src.praxxis.parameter import pull_param
     from tests.src.praxxis.util import dummy_object
     from src.praxxis.parameter import list_param
 
     # args = dummy_object.make_dummy_library()
 
-    # params = list_param.list_param(current_scene_db, query_start, stop)
+    # params = list_param.list_param(current_scene_db, query_start, query_end)
     # assert len(params) == 0
     # pull_param.pull_library_parameter(args, library_db, current_scene_db)
     # assert len(params) == 2

--- a/tests/src/praxxis/parameter/test_set_param.py
+++ b/tests/src/praxxis/parameter/test_set_param.py
@@ -1,6 +1,6 @@
 import argparse 
 
-def test_set_param(setup, scene_root, history_db, current_scene_db, start, stop):
+def test_set_param(setup, scene_root, history_db, current_scene_db, query_start, stop):
     from src.praxxis.parameter import set_param
     from src.praxxis.parameter import list_param
     from src.praxxis.parameter import delete_param
@@ -9,7 +9,7 @@ def test_set_param(setup, scene_root, history_db, current_scene_db, start, stop)
     name1 = dummy_object.make_dummy_parameter("test", "test")
 
     set_param.set_param(name1, scene_root, history_db, current_scene_db)
-    result = list_param.list_param(current_scene_db, start, stop)
+    result = list_param.list_param(current_scene_db, query_start, stop)
 
     assert result[0][0] == name1.name 
     assert result[0][1] == name1.value

--- a/tests/src/praxxis/parameter/test_set_param.py
+++ b/tests/src/praxxis/parameter/test_set_param.py
@@ -1,6 +1,6 @@
 import argparse 
 
-def test_set_param(setup, scene_root, history_db, current_scene_db, query_start, stop):
+def test_set_param(setup, scene_root, history_db, current_scene_db, query_start, query_end):
     from src.praxxis.parameter import set_param
     from src.praxxis.parameter import list_param
     from src.praxxis.parameter import delete_param
@@ -9,7 +9,7 @@ def test_set_param(setup, scene_root, history_db, current_scene_db, query_start,
     name1 = dummy_object.make_dummy_parameter("test", "test")
 
     set_param.set_param(name1, scene_root, history_db, current_scene_db)
-    result = list_param.list_param(current_scene_db, query_start, stop)
+    result = list_param.list_param(current_scene_db, query_start, query_end)
 
     assert result[0][0] == name1.name 
     assert result[0][1] == name1.value

--- a/tests/src/praxxis/rulesengine/test_add_rule.py
+++ b/tests/src/praxxis/rulesengine/test_add_rule.py
@@ -1,6 +1,6 @@
 import pytest
 
-def test_add_rule(setup, monkeypatch, create_one_ruleset, rulesengine_db, library_db, create_one_scene,current_scene_db, query_start, stop):
+def test_add_rule(setup, monkeypatch, create_one_ruleset, rulesengine_db, library_db, create_one_scene,current_scene_db, query_start, query_end):
     from src.praxxis.rulesengine import add_rule_to_ruleset
     from tests.src.praxxis.util import dummy_object
 
@@ -9,7 +9,7 @@ def test_add_rule(setup, monkeypatch, create_one_ruleset, rulesengine_db, librar
     
     with monkeypatch.context() as m:
         m.setattr("builtins.input", lambda _: mock_in)
-        rulename = add_rule_to_ruleset.add_rule_to_ruleset(name1, rulesengine_db, library_db, current_scene_db, query_start, stop)
+        rulename = add_rule_to_ruleset.add_rule_to_ruleset(name1, rulesengine_db, library_db, current_scene_db, query_start, query_end)
 
     from src.praxxis.sqlite import sqlite_rulesengine
     

--- a/tests/src/praxxis/rulesengine/test_add_rule.py
+++ b/tests/src/praxxis/rulesengine/test_add_rule.py
@@ -1,6 +1,6 @@
 import pytest
 
-def test_add_rule(setup, monkeypatch, create_one_ruleset, rulesengine_db, library_db, create_one_scene,current_scene_db, start, stop):
+def test_add_rule(setup, monkeypatch, create_one_ruleset, rulesengine_db, library_db, create_one_scene,current_scene_db, query_start, stop):
     from src.praxxis.rulesengine import add_rule_to_ruleset
     from tests.src.praxxis.util import dummy_object
 
@@ -9,7 +9,7 @@ def test_add_rule(setup, monkeypatch, create_one_ruleset, rulesengine_db, librar
     
     with monkeypatch.context() as m:
         m.setattr("builtins.input", lambda _: mock_in)
-        rulename = add_rule_to_ruleset.add_rule_to_ruleset(name1, rulesengine_db, library_db, current_scene_db, start, stop)
+        rulename = add_rule_to_ruleset.add_rule_to_ruleset(name1, rulesengine_db, library_db, current_scene_db, query_start, stop)
 
     from src.praxxis.sqlite import sqlite_rulesengine
     

--- a/tests/src/praxxis/rulesengine/test_delete_rule.py
+++ b/tests/src/praxxis/rulesengine/test_delete_rule.py
@@ -1,6 +1,6 @@
 import pytest
 
-def test_delete_rule(setup, monkeypatch, create_one_ruleset_one_rule, rulesengine_db, library_db, create_one_scene,current_scene_db, start, stop):
+def test_delete_rule(setup, monkeypatch, create_one_ruleset_one_rule, rulesengine_db, library_db, create_one_scene,current_scene_db, query_start, stop):
     from src.praxxis.rulesengine import delete_rule_from_ruleset
     from src.praxxis.sqlite import sqlite_rulesengine
     from tests.src.praxxis.rulesengine import test_add_rule
@@ -28,7 +28,7 @@ def test_delete_rule(setup, monkeypatch, create_one_ruleset_one_rule, rulesengin
     assert predictions == [] 
     
 
-def test_delete_rule_nonexistent(setup, monkeypatch, create_one_ruleset_one_rule, rulesengine_db, library_db, create_one_scene,current_scene_db, start, stop):
+def test_delete_rule_nonexistent(setup, monkeypatch, create_one_ruleset_one_rule, rulesengine_db, library_db, create_one_scene,current_scene_db, query_start, stop):
     from src.praxxis.rulesengine import delete_rule_from_ruleset
     from src.praxxis.sqlite import sqlite_rulesengine
     from tests.src.praxxis.rulesengine import test_add_rule

--- a/tests/src/praxxis/rulesengine/test_delete_rule.py
+++ b/tests/src/praxxis/rulesengine/test_delete_rule.py
@@ -1,6 +1,6 @@
 import pytest
 
-def test_delete_rule(setup, monkeypatch, create_one_ruleset_one_rule, rulesengine_db, library_db, create_one_scene,current_scene_db, query_start, stop):
+def test_delete_rule(setup, monkeypatch, create_one_ruleset_one_rule, rulesengine_db, library_db, create_one_scene,current_scene_db, query_start, query_end):
     from src.praxxis.rulesengine import delete_rule_from_ruleset
     from src.praxxis.sqlite import sqlite_rulesengine
     from tests.src.praxxis.rulesengine import test_add_rule
@@ -28,7 +28,7 @@ def test_delete_rule(setup, monkeypatch, create_one_ruleset_one_rule, rulesengin
     assert predictions == [] 
     
 
-def test_delete_rule_nonexistent(setup, monkeypatch, create_one_ruleset_one_rule, rulesengine_db, library_db, create_one_scene,current_scene_db, query_start, stop):
+def test_delete_rule_nonexistent(setup, monkeypatch, create_one_ruleset_one_rule, rulesengine_db, library_db, create_one_scene,current_scene_db, query_start, query_end):
     from src.praxxis.rulesengine import delete_rule_from_ruleset
     from src.praxxis.sqlite import sqlite_rulesengine
     from tests.src.praxxis.rulesengine import test_add_rule

--- a/tests/src/praxxis/rulesengine/test_import_ruleset.py
+++ b/tests/src/praxxis/rulesengine/test_import_ruleset.py
@@ -90,7 +90,7 @@ def test_import_database(setup, rulesengine_db, create_one_ruleset):
 
     assert message == name1.name
     
-    rulesets = sqlite_rulesengine.get_all_rulesets(rulesengine_db, start=1, end=5)
+    rulesets = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start=1, end=5)
 
     assert len(rulesets) == 1
     assert len(rulesets[0]) == 2

--- a/tests/src/praxxis/rulesengine/test_import_ruleset.py
+++ b/tests/src/praxxis/rulesengine/test_import_ruleset.py
@@ -90,7 +90,7 @@ def test_import_database(setup, rulesengine_db, create_one_ruleset):
 
     assert message == name1.name
     
-    rulesets = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start=1, end=5)
+    rulesets = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start=1, query_end=5)
 
     assert len(rulesets) == 1
     assert len(rulesets[0]) == 2

--- a/tests/src/praxxis/rulesengine/test_list_rulesets.py
+++ b/tests/src/praxxis/rulesengine/test_list_rulesets.py
@@ -1,6 +1,6 @@
 import pytest
 
-def test_list_rulesets(setup, create_one_ruleset, create_one_ruleset_one_rule, create_deactivated_ruleset, rulesengine_db, query_start, stop):
+def test_list_rulesets(setup, create_one_ruleset, create_one_ruleset_one_rule, create_deactivated_ruleset, rulesengine_db, query_start, query_end):
     from src.praxxis.rulesengine import list_rulesets
     from tests.src.praxxis.util import dummy_object
     from src.praxxis.sqlite import sqlite_rulesengine
@@ -10,7 +10,7 @@ def test_list_rulesets(setup, create_one_ruleset, create_one_ruleset_one_rule, c
     name2 = dummy_object.make_dummy_ruleset("generated_ruleset_with_rule")
     name3 = dummy_object.make_dummy_ruleset("generated_deactivated_ruleset")
     
-    result = list_rulesets.list_rulesets(name1, rulesengine_db, query_start, stop)
+    result = list_rulesets.list_rulesets(name1, rulesengine_db, query_start, query_end)
 
     assert len(result) == 3
     for info in result:

--- a/tests/src/praxxis/rulesengine/test_list_rulesets.py
+++ b/tests/src/praxxis/rulesengine/test_list_rulesets.py
@@ -1,6 +1,6 @@
 import pytest
 
-def test_list_rulesets(setup, create_one_ruleset, create_one_ruleset_one_rule, create_deactivated_ruleset, rulesengine_db, start, stop):
+def test_list_rulesets(setup, create_one_ruleset, create_one_ruleset_one_rule, create_deactivated_ruleset, rulesengine_db, query_start, stop):
     from src.praxxis.rulesengine import list_rulesets
     from tests.src.praxxis.util import dummy_object
     from src.praxxis.sqlite import sqlite_rulesengine
@@ -10,7 +10,7 @@ def test_list_rulesets(setup, create_one_ruleset, create_one_ruleset_one_rule, c
     name2 = dummy_object.make_dummy_ruleset("generated_ruleset_with_rule")
     name3 = dummy_object.make_dummy_ruleset("generated_deactivated_ruleset")
     
-    result = list_rulesets.list_rulesets(name1, rulesengine_db, start, stop)
+    result = list_rulesets.list_rulesets(name1, rulesengine_db, query_start, stop)
 
     assert len(result) == 3
     for info in result:

--- a/tests/src/praxxis/rulesengine/test_new_ruleset.py
+++ b/tests/src/praxxis/rulesengine/test_new_ruleset.py
@@ -1,6 +1,6 @@
 import pytest
 
-def test_new_ruleset(setup, rulesengine_root, rulesengine_db, query_start, stop):
+def test_new_ruleset(setup, rulesengine_root, rulesengine_db, query_start, query_end):
     from src.praxxis.rulesengine import new_ruleset
     from tests.src.praxxis.util import dummy_object
     from src.praxxis.sqlite import sqlite_rulesengine
@@ -11,7 +11,7 @@ def test_new_ruleset(setup, rulesengine_root, rulesengine_db, query_start, stop)
 
     assert message == name1.name
 
-    rulesets = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start, stop)
+    rulesets = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start, query_end)
     assert len(rulesets) == 1
     assert rulesets[0][0] == name1.name
 

--- a/tests/src/praxxis/rulesengine/test_new_ruleset.py
+++ b/tests/src/praxxis/rulesengine/test_new_ruleset.py
@@ -1,6 +1,6 @@
 import pytest
 
-def test_new_ruleset(setup, rulesengine_root, rulesengine_db, start, stop):
+def test_new_ruleset(setup, rulesengine_root, rulesengine_db, query_start, stop):
     from src.praxxis.rulesengine import new_ruleset
     from tests.src.praxxis.util import dummy_object
     from src.praxxis.sqlite import sqlite_rulesengine
@@ -11,7 +11,7 @@ def test_new_ruleset(setup, rulesengine_root, rulesengine_db, start, stop):
 
     assert message == name1.name
 
-    rulesets = sqlite_rulesengine.get_all_rulesets(rulesengine_db, start, stop)
+    rulesets = sqlite_rulesengine.get_all_rulesets(rulesengine_db, query_start, stop)
     assert len(rulesets) == 1
     assert rulesets[0][0] == name1.name
 

--- a/tests/src/praxxis/test_app.py
+++ b/tests/src/praxxis/test_app.py
@@ -498,7 +498,7 @@ def update_model(command):
     assert namespace.command == 'um' or namespace.command == "updatemodel"
     
 
-def test_start(setup, add_test_library, scene_root, library_root, library_db, current_scene_db, start, stop):
+def test_start(setup, add_test_library, scene_root, library_root, library_db, current_scene_db, query_start, stop):
     from src.praxxis import app
     from src.praxxis.sqlite import sqlite_scene
     from src.praxxis.notebook import run_notebook

--- a/tests/src/praxxis/test_app.py
+++ b/tests/src/praxxis/test_app.py
@@ -498,7 +498,7 @@ def update_model(command):
     assert namespace.command == 'um' or namespace.command == "updatemodel"
     
 
-def test_start(setup, add_test_library, scene_root, library_root, library_db, current_scene_db, query_start, stop):
+def test_start(setup, add_test_library, scene_root, library_root, library_db, current_scene_db, query_start, query_end):
     from src.praxxis import app
     from src.praxxis.sqlite import sqlite_scene
     from src.praxxis.notebook import run_notebook

--- a/tests/src/praxxis/util/test_cli.py
+++ b/tests/src/praxxis/util/test_cli.py
@@ -16,7 +16,7 @@ def test_command(setup,
          model_db,
          default_scene_name,
          current_scene_db,
-         start,
+         query_start,
          stop):
     import os
     from src.praxxis.sqlite import sqlite_scene
@@ -45,7 +45,7 @@ def test_command(setup,
     from src.praxxis.telemetry import update_settings 
 
 
-    list_notebook.list_notebook(library_db, current_scene_db, start, stop)
+    list_notebook.list_notebook(library_db, current_scene_db, query_start, stop)
 
     dummy_input = dummy_object.make_dummy_input("run_notebook")
     result = cli.command(dummy_input, init_root, library_root, library_db, output_root, scene_root, history_db, telemetry_db, rulesengine_root, rulesengine_db, model_root, model_db, default_scene_name, True)

--- a/tests/src/praxxis/util/test_cli.py
+++ b/tests/src/praxxis/util/test_cli.py
@@ -17,7 +17,7 @@ def test_command(setup,
          default_scene_name,
          current_scene_db,
          query_start,
-         stop):
+         query_end):
     import os
     from src.praxxis.sqlite import sqlite_scene
     from src.praxxis.notebook import list_notebook
@@ -45,7 +45,7 @@ def test_command(setup,
     from src.praxxis.telemetry import update_settings 
 
 
-    list_notebook.list_notebook(library_db, current_scene_db, query_start, stop)
+    list_notebook.list_notebook(library_db, current_scene_db, query_start, query_end)
 
     dummy_input = dummy_object.make_dummy_input("run_notebook")
     result = cli.command(dummy_input, init_root, library_root, library_db, output_root, scene_root, history_db, telemetry_db, rulesengine_root, rulesengine_db, model_root, model_db, default_scene_name, True)


### PR DESCRIPTION
A short and sweet PR to enforce query_start and query_end as the variable names here :)

resolves #6 